### PR TITLE
Restore custom port support dropped on 1.0.7

### DIFF
--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -74,8 +74,17 @@ class WP_API_SwaggerUI {
         wp_send_json( $response );
     }
 
-    public function getHost() {
-        return parse_url(home_url(), PHP_URL_HOST);
+	public function getHost() {
+        $host = parse_url(home_url(), PHP_URL_HOST);
+        $port = parse_url(home_url(), PHP_URL_PORT);
+
+        if ( $port ) {
+            if ( $port != 80 && $port != 443 ) {
+                $host = $host . ':' . $port;
+            }
+        }
+
+        return $host;
     }
 
     public function getBasePath() {


### PR DESCRIPTION
Thanks for fixing the subdirectory installation issue #2. However, after updating to 1.0.7, the plugin fails to send request to endpoint because our dev servers are running on port 8000.

It looks regression by changing implementation of `getHost()` , so this is the fix of that by appending port if it is not 80 or 443.