### PR TITLE
Add support for multiple url params in the url

### DIFF
--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -157,7 +157,7 @@ class WP_API_SwaggerUI
     {
 
         if (mb_strpos($endpoint, '(?P<') !== false) {
-            $endpoint = preg_replace_callback('/\(\?P\<(.*?)>(.*)\)+/', function ($match) use ($endpoint) {
+            $endpoint = preg_replace_callback('/\(\?P\<(.*?)>(.*?)\)+/', function ($match) use ($endpoint) {
                 return '{' . $match[1] . '}';
             }, $endpoint);
         }
@@ -255,7 +255,7 @@ class WP_API_SwaggerUI
     {
         $path_params = [];
 
-        if (mb_strpos($endpoint, '(?P<') !== false && (preg_match_all('/\(\?P\<(.*?)>(.*)\)/', $endpoint, $matches))) {
+        if (mb_strpos($endpoint, '(?P<') !== false && (preg_match_all('/\(\?P\<(.*?)>(.*?)\)/', $endpoint, $matches))) {
             foreach ($matches[1] as $order => $match) {
                 $type = strpos(mb_strtolower($matches[2][$order]), '\d') !== false ? 'integer' : 'string';
                 $params = array(


### PR DESCRIPTION
Currently the url paths in the swagger ui are broken whenever the url has multiple url params. This PR modifies the regex so it works with random amount of params. Still need to update `getDefaultTagsFromEndpoint` function, so it also supports multiple parameters - it has been done in [this PR](https://github.com/jonyextenz/wp-api-swaggerui/pull/14) 🙂

## Before ##
![Zrzut ekranu 2022-10-1 o 22 40 53](https://user-images.githubusercontent.com/26175185/193427634-2767fe3d-c3e2-4ba5-ab3d-3e86a5cf3c6b.png)

## After ##
![Zrzut ekranu 2022-10-1 o 22 43 37](https://user-images.githubusercontent.com/26175185/193427649-659e8bf2-05a2-4b75-91db-41713eb51ca1.png)

