### PR TITLE
Fix generating default tags

### DIFF
--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -168,9 +168,14 @@ class WP_API_SwaggerUI
     public function getDefaultTagsFromEndpoint($endpoint)
     {
         $namespace = self::getNameSpace();
+        // Remove namespace
         $ep = preg_replace_callback('/^' . preg_quote($namespace, '/') . '/', function () {
             return '';
         }, $endpoint);
+        // Remove url parameters
+        $ep = preg_replace_callback('/\(\?P\<(.*?)>(.*?)\)+/', function () {
+            return '';
+        }, $ep);
         $parts = explode('/', trim($ep, '/'));
         return isset($parts[0]) ? [$parts[0]] : [];
     }


### PR DESCRIPTION
This PR fixes generating default tags so it takes the first part of the url which is neither namespace nor url parameter.

## Before ##
![Zrzut ekranu 2022-10-6 o 21 22 50](https://user-images.githubusercontent.com/26175185/194401405-d0c22f68-c272-4659-8fbd-9a6800f1b72a.png)

## After ##
![Zrzut ekranu 2022-10-6 o 21 23 11](https://user-images.githubusercontent.com/26175185/194401460-510bd678-fe1f-4b2c-8600-d897532b9835.png)

