### PR TITLE
Fix named-param REST route handling (recursive regex + tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-api-swaggerui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "SwaggerUI for WordPress",
   "main": "index.js",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/agussuroyo
 Tags: swaggerui, wp swaggerui, wp rest api, wp swagger rest api, swaggerui rest api, swagger rest api, wp swagger, api, swagger, rest api
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -36,6 +36,10 @@ This plugin can be installed directly from your site.
 2. Options to choose namespace Rest API
 
 == Changelog ==
+
+= 2.0.1 =
+* Fix REST routes with multiple or nested named parameters in the generated docs
+* Fix default tag for routes that start with a named parameter
 
 = 2.0.0 =
 * Compatibility with WordPress 7.0 and PHP 8

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -49,6 +49,28 @@ class TestSwaggerUI extends WP_UnitTestCase {
 	public function test_convertEndpoint() {
 		$this->assertEquals( '/sample/endpoint/{sample_id}', $this->ui->convertEndpoint( '/sample/endpoint/(?P<sample_id>)' ) );
         $this->assertEquals( '/other/{other_id}/edit', $this->ui->convertEndpoint( '/other/(?P<other_id>[^.\/]+(?:\/[^.\/]+)?)/edit' ) );
+        // Multiple params in one route must each convert, not collapse into the first.
+        $this->assertEquals( '/parent/{parent_id}/child/{child_id}', $this->ui->convertEndpoint( '/parent/(?P<parent_id>[\d]+)/child/(?P<child_id>[\d]+)' ) );
+        // A parameter pattern may nest parens to any depth.
+        $this->assertEquals( '/x/{slug}', $this->ui->convertEndpoint( '/x/(?P<slug>[a-z]+(?:-[a-z]+(?:-[a-z]+)?)?)' ) );
+        // A literal ')' inside a character class must not end the group early.
+        $this->assertEquals( '/x/{slug}/y', $this->ui->convertEndpoint( '/x/(?P<slug>[^/)]+)/y' ) );
+	}
+
+	public function test_getDefaultTagsFromEndpoint() {
+		$this->assertEquals( [ 'posts' ], $this->ui->getDefaultTagsFromEndpoint( '/wp/v2/posts' ) );
+		// A leading named param must not become the tag.
+		$this->assertEquals( [ 'revisions' ], $this->ui->getDefaultTagsFromEndpoint( '/wp/v2/(?P<parent>[\d]+)/revisions' ) );
+	}
+
+	public function test_getParametersFromEndpoint() {
+		$params = $this->ui->getParametersFromEndpoint( '/parent/(?P<parent_id>[\d]+)/child/(?P<child_slug>[\w]+)' );
+
+		$this->assertCount( 2, $params );
+		$this->assertArrayHasKey( 'parent_id', $params );
+		$this->assertArrayHasKey( 'child_slug', $params );
+		$this->assertEquals( 'integer', $params['parent_id']['type'] );
+		$this->assertEquals( 'string', $params['child_slug']['type'] );
 	}
 
     public function test_detectIn() {

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -158,7 +158,11 @@ class WP_API_SwaggerUI
     {
 
         if (mb_strpos($endpoint, '(?P<') !== false) {
-            $endpoint = preg_replace_callback('/\(\?P\<(.*?)>(.*)\)+/', function ($match) use ($endpoint) {
+            // Match each named group separately (multi-param routes). Atoms:
+            // escaped char, char class [...], or a (?3)-recursive balanced group,
+            // so a param regex may nest parens to any depth and may contain a
+            // literal ')' inside a class or escape without ending the group early.
+            $endpoint = preg_replace_callback('/\(\?P<([^>]+)>((?:\\\\.|\[[^\]]*\]|(\((?:\\\\.|\[[^\]]*\]|[^()]|(?3))*\))|[^()])*)\)/', function ($match) {
                 return '{' . $match[1] . '}';
             }, $endpoint);
         }
@@ -172,7 +176,12 @@ class WP_API_SwaggerUI
         $ep = preg_replace_callback('/^' . preg_quote($namespace, '/') . '/', function () {
             return '';
         }, $endpoint);
-        $parts = explode('/', trim($ep, '/'));
+        // Strip named parameters so the tag comes from a real path segment,
+        // not a raw (?P<...>) regex. Same recursive match as convertEndpoint.
+        $ep = preg_replace_callback('/\(\?P<([^>]+)>((?:\\\\.|\[[^\]]*\]|(\((?:\\\\.|\[[^\]]*\]|[^()]|(?3))*\))|[^()])*)\)/', function () {
+            return '';
+        }, $ep);
+        $parts = array_values(array_filter(explode('/', trim($ep, '/'))));
         return isset($parts[0]) ? [$parts[0]] : [];
     }
 
@@ -256,7 +265,7 @@ class WP_API_SwaggerUI
     {
         $path_params = [];
 
-        if (mb_strpos($endpoint, '(?P<') !== false && (preg_match_all('/\(\?P\<(.*?)>(.*)\)/', $endpoint, $matches))) {
+        if (mb_strpos($endpoint, '(?P<') !== false && (preg_match_all('/\(\?P<([^>]+)>((?:\\\\.|\[[^\]]*\]|(\((?:\\\\.|\[[^\]]*\]|[^()]|(?3))*\))|[^()])*)\)/', $endpoint, $matches))) {
             foreach ($matches[1] as $order => $match) {
                 $type = strpos(mb_strtolower($matches[2][$order]), '\d') !== false ? 'integer' : 'string';
                 $params = array(

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: WP API SwaggerUI
  * Description: WordPress REST API with Swagger UI.
- * Version:     2.0.0
+ * Version:     2.0.1
  * Author:      Agus Suroyo
  * Requires PHP: 7.4
  * License:     GPL v2 or later


### PR DESCRIPTION
Fixes named-param handling for routes with multiple params and params whose regex nests parens.

Uses a recursive paren-balanced regex so each `(?P<name>...)` is matched independently at any depth, applied in three places:
- `convertEndpoint` — build the `{name}` path
- `getParametersFromEndpoint` — extract params + type
- `getDefaultTagsFromEndpoint` — strip params so the tag is a real path segment, not a raw regex

The old greedy pattern collapsed multi-param routes; a plain lazy pattern (#13) broke nested ones.

Adds tests for multi-param conversion, deep nesting, type detection, and tag derivation. Full suite passes (23 tests). Verified live in Swagger UI on WP 7.0.

Builds on @grzegorz-bach's fixes in #13 and #14 — this generalizes the regex to cover nested/multi-param cases and adds tests. Supersedes both.