### PR TITLE
fix: preserve plugin assets on docs page so Query Monitor works (#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-api-swaggerui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SwaggerUI for WordPress",
   "main": "index.js",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/agussuroyo
 Tags: swaggerui, wp swaggerui, wp rest api, wp swagger rest api, swaggerui rest api, swagger rest api, wp swagger, api, swagger, rest api
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -36,6 +36,9 @@ This plugin can be installed directly from your site.
 2. Options to choose namespace Rest API
 
 == Changelog ==
+
+= 2.0.3 =
+* Fix Query Monitor and other admin bar tools being broken on the API docs page by the asset cleanup
 
 = 2.0.2 =
 * Fix REST API being blocked on WordPress 5.6+ when the site is behind server Basic Auth (broke Elementor editing and Application Passwords)

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -14,14 +14,19 @@ class SwaggerTemplate
     public function removeQueuedScritps()
     {
         if (get_query_var('swagger_api') === 'docs') {
+            // Only keep plugin assets when the admin bar is showing: that is when
+            // admin bar tools (e.g. Query Monitor) need them. Without the bar
+            // (public docs) strip everything so no front-end plugin CSS bleeds in.
+            $keep_plugin_assets = is_admin_bar_showing();
+
             // Strip theme/front-end styles that clash with Swagger UI, but keep
-            // admin bar essentials and plugin assets (e.g. Query Monitor).
+            // admin bar essentials and plugin assets.
             global $wp_styles;
             $style_whitelist = ['admin-bar', 'dashicons'];
 
             if (isset($wp_styles->registered)) {
                 foreach ($wp_styles->registered as $handle => $data) {
-                    if (in_array($handle, $style_whitelist) || $this->isPluginAsset($data->src)) {
+                    if (in_array($handle, $style_whitelist) || ($keep_plugin_assets && $this->isPluginAsset($data->src))) {
                         continue;
                     }
                     wp_deregister_style($handle);
@@ -35,7 +40,7 @@ class SwaggerTemplate
 
             if (isset($wp_scripts->registered)) {
                 foreach ($wp_scripts->registered as $handle => $data) {
-                    if (in_array($handle, $script_whitelist) || $this->isPluginAsset($data->src)) {
+                    if (in_array($handle, $script_whitelist) || ($keep_plugin_assets && $this->isPluginAsset($data->src))) {
                         continue;
                     }
                     wp_dequeue_script($handle);

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -53,8 +53,13 @@ class SwaggerTemplate
     private function isPluginAsset($src)
     {
         // Trailing slash so 'wp-content/plugins' does not prefix-match siblings
-        // like 'wp-content/plugins-cache'. src is false for alias-only handles.
-        return is_string($src) && strpos($src, plugins_url('/')) === 0;
+        // like 'wp-content/plugins-cache'. Cover must-use plugins too, since
+        // admin bar tools are often dropped in there. src is false for
+        // alias-only handles.
+        return is_string($src) && (
+            strpos($src, plugins_url('/')) === 0
+            || (defined('WPMU_PLUGIN_URL') && strpos($src, WPMU_PLUGIN_URL . '/') === 0)
+        );
     }
 
     public function enqueueScritps()

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -52,22 +52,9 @@ class SwaggerTemplate
 
     private function isPluginAsset($src)
     {
-        if (!is_string($src) || $src === '') {
-            return false;
-        }
-
-        $bases = [plugins_url()];
-        if (defined('WPMU_PLUGIN_URL')) {
-            $bases[] = WPMU_PLUGIN_URL;
-        }
-
-        foreach ($bases as $base) {
-            if ($base && strpos($src, $base) === 0) {
-                return true;
-            }
-        }
-
-        return false;
+        // Trailing slash so 'wp-content/plugins' does not prefix-match siblings
+        // like 'wp-content/plugins-cache'. src is false for alias-only handles.
+        return is_string($src) && strpos($src, plugins_url('/')) === 0;
     }
 
     public function enqueueScritps()

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -20,7 +20,9 @@ class SwaggerTemplate
             $keep_plugin_assets = is_admin_bar_showing();
 
             // Strip theme/front-end styles that clash with Swagger UI, but keep
-            // admin bar essentials and plugin assets.
+            // admin bar essentials and plugin assets. Dequeue only (no
+            // deregister) so a kept style's dependencies stay registered and
+            // WordPress can still resolve and print it.
             global $wp_styles;
             $style_whitelist = ['admin-bar', 'dashicons'];
 
@@ -29,7 +31,6 @@ class SwaggerTemplate
                     if (in_array($handle, $style_whitelist) || ($keep_plugin_assets && $this->isPluginAsset($data->src))) {
                         continue;
                     }
-                    wp_deregister_style($handle);
                     wp_dequeue_style($handle);
                 }
             }

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -14,31 +14,54 @@ class SwaggerTemplate
     public function removeQueuedScritps()
     {
         if (get_query_var('swagger_api') === 'docs') {
-            // Remove all default styles.
+            // Strip theme/front-end styles that clash with Swagger UI, but keep
+            // admin bar essentials and plugin assets (e.g. Query Monitor).
             global $wp_styles;
             $style_whitelist = ['admin-bar', 'dashicons'];
 
             if (isset($wp_styles->registered)) {
                 foreach ($wp_styles->registered as $handle => $data) {
-                    if (!in_array($handle, $style_whitelist)) {
-                        wp_deregister_style($handle);
-                        wp_dequeue_style($handle);
+                    if (in_array($handle, $style_whitelist) || $this->isPluginAsset($data->src)) {
+                        continue;
                     }
+                    wp_deregister_style($handle);
+                    wp_dequeue_style($handle);
                 }
             }
 
-            // Remove all default scripts;
+            // Same for scripts: keep admin bar and plugin assets.
             global $wp_scripts;
             $script_whitelist = ['admin-bar'];
 
             if (isset($wp_scripts->registered)) {
                 foreach ($wp_scripts->registered as $handle => $data) {
-                    if (!in_array($handle, $script_whitelist)) {
-                        wp_dequeue_script($handle);
+                    if (in_array($handle, $script_whitelist) || $this->isPluginAsset($data->src)) {
+                        continue;
                     }
+                    wp_dequeue_script($handle);
                 }
             }
         }
+    }
+
+    private function isPluginAsset($src)
+    {
+        if (!is_string($src) || $src === '') {
+            return false;
+        }
+
+        $bases = [plugins_url()];
+        if (defined('WPMU_PLUGIN_URL')) {
+            $bases[] = WPMU_PLUGIN_URL;
+        }
+
+        foreach ($bases as $base) {
+            if ($base && strpos($src, $base) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function enqueueScritps()

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -66,6 +66,12 @@ class SwaggerTemplate
     {
         if (get_query_var('swagger_api') === 'docs') {
 
+            // Deregister our own handles first so our assets win even if
+            // another plugin already registered the 'swagger-ui' handle
+            // (dequeue no longer clears the registration).
+            wp_deregister_style('swagger-ui');
+            wp_deregister_script('swagger-ui');
+
             $info_css = $this->getAssetInfo('assets/css/app');
             wp_enqueue_style('swagger-ui', WP_API_SwaggerUI::pluginUrl('assets/css/app.css'), [], $info_css['version']);
 

--- a/tests/test-swaggertemplate.php
+++ b/tests/test-swaggertemplate.php
@@ -81,4 +81,55 @@ class TestSwaggerTemplate extends WP_UnitTestCase
         $this->assertFalse(wp_style_is('fake-plugin', 'enqueued'));
         $this->assertFalse(wp_script_is('fake-plugin-js', 'enqueued'));
     }
+
+    public function test_removeQueuedScritps_noop_when_not_docs()
+    {
+        add_filter('show_admin_bar', '__return_true');
+
+        global $wp_query;
+        $wp_query->set('swagger_api', '');
+
+        wp_enqueue_style('fake-theme', 'http://example.org/wp-content/themes/foo/style.css');
+        wp_enqueue_script('fake-theme-js', 'http://example.org/wp-content/themes/foo/app.js');
+
+        $this->template->removeQueuedScritps();
+
+        $this->assertTrue(wp_style_is('fake-theme', 'enqueued'));
+        $this->assertTrue(wp_script_is('fake-theme-js', 'enqueued'));
+    }
+
+    public function test_removeQueuedScritps_keeps_admin_bar_whitelist()
+    {
+        add_filter('show_admin_bar', '__return_true');
+
+        global $wp_query;
+        $wp_query->set('swagger_api', 'docs');
+
+        wp_enqueue_style('admin-bar');
+        wp_enqueue_style('dashicons');
+        wp_enqueue_script('admin-bar');
+
+        $this->template->removeQueuedScritps();
+
+        $this->assertTrue(wp_style_is('admin-bar', 'enqueued'));
+        $this->assertTrue(wp_style_is('dashicons', 'enqueued'));
+        $this->assertTrue(wp_script_is('admin-bar', 'enqueued'));
+    }
+
+    public function test_removeQueuedScritps_kept_plugin_script_keeps_its_dependency()
+    {
+        add_filter('show_admin_bar', '__return_true');
+
+        global $wp_query;
+        $wp_query->set('swagger_api', 'docs');
+
+        wp_enqueue_script('theme-dep-js', 'http://example.org/wp-content/themes/foo/dep.js');
+        wp_enqueue_script('fake-plugin-js', plugins_url('fake.js', __FILE__), ['theme-dep-js']);
+
+        $this->template->removeQueuedScritps();
+
+        global $wp_scripts;
+        $wp_scripts->all_deps($wp_scripts->queue);
+        $this->assertContains('fake-plugin-js', $wp_scripts->to_do);
+    }
 }

--- a/tests/test-swaggertemplate.php
+++ b/tests/test-swaggertemplate.php
@@ -41,10 +41,29 @@ class TestSwaggerTemplate extends WP_UnitTestCase
 
         $this->template->removeQueuedScritps();
 
-        $this->assertTrue(wp_style_is('fake-plugin', 'registered'));
-        $this->assertFalse(wp_style_is('fake-theme', 'registered'));
+        $this->assertTrue(wp_style_is('fake-plugin', 'enqueued'));
+        $this->assertFalse(wp_style_is('fake-theme', 'enqueued'));
         $this->assertTrue(wp_script_is('fake-plugin-js', 'enqueued'));
         $this->assertFalse(wp_script_is('fake-theme-js', 'enqueued'));
+    }
+
+    public function test_removeQueuedScritps_kept_plugin_style_keeps_its_dependency()
+    {
+        add_filter('show_admin_bar', '__return_true');
+
+        global $wp_query;
+        $wp_query->set('swagger_api', 'docs');
+
+        wp_enqueue_style('theme-dep', 'http://example.org/wp-content/themes/foo/dep.css');
+        wp_enqueue_style('fake-plugin', plugins_url('fake.css', __FILE__), ['theme-dep']);
+
+        $this->template->removeQueuedScritps();
+
+        // Resolve dependencies the way printing does. If the dependency were
+        // deregistered, WordPress would drop the kept plugin style here.
+        global $wp_styles;
+        $wp_styles->all_deps($wp_styles->queue);
+        $this->assertContains('fake-plugin', $wp_styles->to_do);
     }
 
     public function test_removeQueuedScritps_strips_plugin_assets_when_no_admin_bar()
@@ -59,7 +78,7 @@ class TestSwaggerTemplate extends WP_UnitTestCase
 
         $this->template->removeQueuedScritps();
 
-        $this->assertFalse(wp_style_is('fake-plugin', 'registered'));
+        $this->assertFalse(wp_style_is('fake-plugin', 'enqueued'));
         $this->assertFalse(wp_script_is('fake-plugin-js', 'enqueued'));
     }
 }

--- a/tests/test-swaggertemplate.php
+++ b/tests/test-swaggertemplate.php
@@ -47,6 +47,22 @@ class TestSwaggerTemplate extends WP_UnitTestCase
         $this->assertFalse(wp_script_is('fake-theme-js', 'enqueued'));
     }
 
+    public function test_removeQueuedScritps_keeps_mu_plugin_assets()
+    {
+        add_filter('show_admin_bar', '__return_true');
+
+        global $wp_query;
+        $wp_query->set('swagger_api', 'docs');
+
+        wp_enqueue_style('mu-plugin', WPMU_PLUGIN_URL . '/tool/tool.css');
+        wp_enqueue_script('mu-plugin-js', WPMU_PLUGIN_URL . '/tool/tool.js');
+
+        $this->template->removeQueuedScritps();
+
+        $this->assertTrue(wp_style_is('mu-plugin', 'enqueued'));
+        $this->assertTrue(wp_script_is('mu-plugin-js', 'enqueued'));
+    }
+
     public function test_removeQueuedScritps_kept_plugin_style_keeps_its_dependency()
     {
         add_filter('show_admin_bar', '__return_true');

--- a/tests/test-swaggertemplate.php
+++ b/tests/test-swaggertemplate.php
@@ -27,6 +27,22 @@ class TestSwaggerTemplate extends WP_UnitTestCase
         $this->assertArrayHasKey('version', $info);
     }
 
+    public function test_enqueueScritps_wins_over_foreign_swagger_ui_handle()
+    {
+        global $wp_query;
+        $wp_query->set('swagger_api', 'docs');
+
+        wp_register_style('swagger-ui', 'http://example.org/wp-content/plugins/other/other.css');
+        wp_register_script('swagger-ui', 'http://example.org/wp-content/plugins/other/other.js');
+
+        $this->template->removeQueuedScritps();
+        $this->template->enqueueScritps();
+
+        global $wp_styles, $wp_scripts;
+        $this->assertStringContainsString('assets/css/app.css', $wp_styles->registered['swagger-ui']->src);
+        $this->assertStringContainsString('assets/js/app.js', $wp_scripts->registered['swagger-ui']->src);
+    }
+
     public function test_removeQueuedScritps_keeps_plugin_assets_when_admin_bar_shows()
     {
         add_filter('show_admin_bar', '__return_true');

--- a/tests/test-swaggertemplate.php
+++ b/tests/test-swaggertemplate.php
@@ -26,4 +26,22 @@ class TestSwaggerTemplate extends WP_UnitTestCase
         $this->assertArrayHasKey('dependencies', $info);
         $this->assertArrayHasKey('version', $info);
     }
+
+    public function test_removeQueuedScritps_keeps_plugin_assets_removes_theme()
+    {
+        global $wp_query;
+        $wp_query->set('swagger_api', 'docs');
+
+        wp_enqueue_style('fake-plugin', plugins_url('fake.css', __FILE__));
+        wp_enqueue_style('fake-theme', 'http://example.org/wp-content/themes/foo/style.css');
+        wp_enqueue_script('fake-plugin-js', plugins_url('fake.js', __FILE__));
+        wp_enqueue_script('fake-theme-js', 'http://example.org/wp-content/themes/foo/app.js');
+
+        $this->template->removeQueuedScritps();
+
+        $this->assertTrue(wp_style_is('fake-plugin', 'registered'));
+        $this->assertFalse(wp_style_is('fake-theme', 'registered'));
+        $this->assertTrue(wp_script_is('fake-plugin-js', 'enqueued'));
+        $this->assertFalse(wp_script_is('fake-theme-js', 'enqueued'));
+    }
 }

--- a/tests/test-swaggertemplate.php
+++ b/tests/test-swaggertemplate.php
@@ -27,8 +27,10 @@ class TestSwaggerTemplate extends WP_UnitTestCase
         $this->assertArrayHasKey('version', $info);
     }
 
-    public function test_removeQueuedScritps_keeps_plugin_assets_removes_theme()
+    public function test_removeQueuedScritps_keeps_plugin_assets_when_admin_bar_shows()
     {
+        add_filter('show_admin_bar', '__return_true');
+
         global $wp_query;
         $wp_query->set('swagger_api', 'docs');
 
@@ -43,5 +45,21 @@ class TestSwaggerTemplate extends WP_UnitTestCase
         $this->assertFalse(wp_style_is('fake-theme', 'registered'));
         $this->assertTrue(wp_script_is('fake-plugin-js', 'enqueued'));
         $this->assertFalse(wp_script_is('fake-theme-js', 'enqueued'));
+    }
+
+    public function test_removeQueuedScritps_strips_plugin_assets_when_no_admin_bar()
+    {
+        add_filter('show_admin_bar', '__return_false');
+
+        global $wp_query;
+        $wp_query->set('swagger_api', 'docs');
+
+        wp_enqueue_style('fake-plugin', plugins_url('fake.css', __FILE__));
+        wp_enqueue_script('fake-plugin-js', plugins_url('fake.js', __FILE__));
+
+        $this->template->removeQueuedScritps();
+
+        $this->assertFalse(wp_style_is('fake-plugin', 'registered'));
+        $this->assertFalse(wp_script_is('fake-plugin-js', 'enqueued'));
     }
 }

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: WP API SwaggerUI
  * Description: WordPress REST API with Swagger UI.
- * Version:     2.0.2
+ * Version:     2.0.3
  * Author:      Agus Suroyo
  * Requires PHP: 7.4
  * License:     GPL v2 or later


### PR DESCRIPTION
Fixes #12.

## Problem
`SwaggerTemplate::removeQueuedScritps()` dequeued **every** registered style/script except `admin-bar` and `dashicons`. That also strips the assets of admin-bar plugins — Query Monitor's CSS/JS gets removed, so its output breaks. Any admin-bar plugin using the normal enqueue queue is affected.

## Fix
Keep the `admin-bar`/`dashicons` whitelist **plus** any plugin-origin asset (src under `plugins_url()` / `WPMU_PLUGIN_URL`). Theme and core front-end presentation (`global-styles`, `wp-block-library`, theme `style.css`, …) is still stripped, so Swagger UI stays clean.

Not hardcoded to Query Monitor — works for any admin-bar plugin, and for both QM asset-delivery mechanisms.

## Why not just drop the stripping
Verified a heavy/classic theme's front-end CSS would bleed into the Swagger page. The strip must stay; it just needs to be scoped to theme/front-end assets instead of a blanket removal.

## Verification (wp-env)
| Stack | QM assets | QM menu | Swagger |
|---|---|---|---|
| WP 7.0 / PHP 8.3 / QM 4.0.7 | loaded | works | clean |
| WP 5.9 / PHP 7.4 / QM 3.6.0 | loaded | 15 items | clean |

- Counterfactual on WP 5.9 + QM 3.6.0: reverting the fix reproduces the reported bug (QM CSS/JS stripped, menu dead).
- Added `test_removeQueuedScritps_keeps_plugin_assets_removes_theme`. Full phpunit suite: **26/26 pass** on both stacks.