### PR TITLE
Add Bearer token (Authorization header) support to Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ SwaggerUI used to make WordPress REST API endpoint have a interactive UI, so we 
 ### Features
 - Support for `GET`, `POST`, `PUT`, `PATCH` and `DELETE` request methods
 - Support for Auth Basic authorization method
+- Support for Bearer token (`Authorization` header) authorization method
 - Choose which namespace API that will be used on the SwaggerUI
 
 ![alt text](https://i.ibb.co/p0Kjhpn/Screen-Shot-2019-07-25-at-08-57-32.png)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/agussuroyo
 Tags: swaggerui, wp swaggerui, wp rest api, wp swagger rest api, swaggerui rest api, swagger rest api, wp swagger, api, swagger, rest api
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 2.0.3
+Stable tag: 2.1.0
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -36,6 +36,11 @@ This plugin can be installed directly from your site.
 2. Options to choose namespace Rest API
 
 == Changelog ==
+
+= 2.1.0 =
+* Add Bearer token (Authorization header) support in the Swagger UI Authorize dialog
+* Add a setting to choose which auth methods (Basic / Bearer) appear in Swagger UI
+* Fix a Bearer Authorization header being misparsed as Basic on the REDIRECT_HTTP_AUTHORIZATION path
 
 = 2.0.3 =
 * Fix Query Monitor and other admin bar tools being broken on the API docs page by the asset cleanup

--- a/swaggerauth.php
+++ b/swaggerauth.php
@@ -90,9 +90,26 @@ class SwaggerAuth {
 			$auth = [];
 		}
 
-		$auth['basic'] = array(
-			'type' => 'basic'
-		);
+		$schemes = (array) get_option( 'swagger_api_auth_schemes', array( 'basic' ) );
+
+		if ( in_array( 'basic', $schemes, true ) ) {
+			$auth['basic'] = array(
+				'type' => 'basic',
+			);
+		}
+
+		if ( in_array( 'bearer', $schemes, true ) ) {
+			// ponytail: Swagger 2.0 has no native bearer type — apiKey-in-header
+			// named Authorization is the standard representation. We only emit
+			// the definition so Swagger UI sends the header; validating the
+			// token is the site's JWT plugin's job, not ours.
+			$auth['bearer'] = array(
+				'type'        => 'apiKey',
+				'name'        => 'Authorization',
+				'in'          => 'header',
+				'description' => 'Enter your token as: `Bearer <token>`',
+			);
+		}
 
 		return $auth;
 	}

--- a/swaggerauth.php
+++ b/swaggerauth.php
@@ -14,15 +14,13 @@ class SwaggerAuth {
 
 		// Check that we're trying to authenticate
 		if ( ! $server->has( 'PHP_AUTH_USER' ) ) {
-			
-			$user_pass = $server->get( 'REDIRECT_HTTP_AUTHORIZATION' );
-			if ( $server->has( 'REDIRECT_HTTP_AUTHORIZATION' ) && ! empty( $user_pass )  ) {
-				list($username, $password) = explode( ':', base64_decode( substr( $user_pass, 6 ) ) );
-				$server->set( 'PHP_AUTH_USER', $username );
-				$server->set( 'PHP_AUTH_PW', $password );
-			} else {
+
+			$creds = self::parseBasicHeader( $server->get( 'REDIRECT_HTTP_AUTHORIZATION' ) );
+			if ( $creds === null ) {
 				return $user_id;
 			}
+			$server->set( 'PHP_AUTH_USER', $creds[0] );
+			$server->set( 'PHP_AUTH_PW', $creds[1] );
 		}
 
 		$username	 = $server->get( 'PHP_AUTH_USER' );
@@ -57,6 +55,25 @@ class SwaggerAuth {
 		$this->error = true;
 
 		return $user->ID;
+	}
+
+	/**
+	 * Parse a Basic auth header into [username, password].
+	 * Returns null for non-Basic values (e.g. Bearer), so a Bearer token in
+	 * REDIRECT_HTTP_AUTHORIZATION is never mis-decoded into fake credentials.
+	 * public + static so the suite can test it without reflection.
+	 */
+	public static function parseBasicHeader( $value ) {
+		if ( ! is_string( $value ) || stripos( $value, 'Basic ' ) !== 0 ) {
+			return null;
+		}
+
+		$decoded = base64_decode( substr( $value, 6 ), true );
+		if ( $decoded === false || strpos( $decoded, ':' ) === false ) {
+			return null;
+		}
+
+		return explode( ':', $decoded, 2 );
 	}
 
 	public function error( $error ) {

--- a/swaggersetting.php
+++ b/swaggersetting.php
@@ -32,7 +32,7 @@ class SwaggerSetting {
 		$data['swagger_api_basepath']	 = WP_API_SwaggerUI::getCLeanNameSpace();
 		$data['namespaces']				 = rest_get_server()->get_namespaces();
 		$data['docs_url']				 = home_url( untrailingslashit( WP_API_SwaggerUI::rewriteBaseApi() ) . '/docs' );
-		$data['swagger_api_auth_schemes'] = get_option( 'swagger_api_auth_schemes', array( 'basic' ) );
+		$data['swagger_api_auth_schemes'] = (array) get_option( 'swagger_api_auth_schemes', array( 'basic' ) );
 
 		echo self::template( 'setting', $data );
 	}

--- a/swaggersetting.php
+++ b/swaggersetting.php
@@ -14,6 +14,9 @@ class SwaggerSetting {
 				update_option( 'swagger_api_basepath', sanitize_text_field( $_POST['swagger_api_basepath'] ) );
 			}
 
+			$schemes = (array) ( isset( $_POST['swagger_api_auth_schemes'] ) ? $_POST['swagger_api_auth_schemes'] : array() );
+			update_option( 'swagger_api_auth_schemes', array_values( array_intersect( array( 'basic', 'bearer' ), $schemes ) ) );
+
 			add_action( 'admin_notices', [ $this, 'notices' ] );
 		}
 	}
@@ -29,6 +32,7 @@ class SwaggerSetting {
 		$data['swagger_api_basepath']	 = WP_API_SwaggerUI::getCLeanNameSpace();
 		$data['namespaces']				 = rest_get_server()->get_namespaces();
 		$data['docs_url']				 = home_url( untrailingslashit( WP_API_SwaggerUI::rewriteBaseApi() ) . '/docs' );
+		$data['swagger_api_auth_schemes'] = get_option( 'swagger_api_auth_schemes', array( 'basic' ) );
 
 		echo self::template( 'setting', $data );
 	}

--- a/template/setting.php
+++ b/template/setting.php
@@ -17,7 +17,21 @@
 							?>
 						</select>
 					</td>
-				</tr>	
+				</tr>
+				<tr>
+					<th>Authentication</th>
+					<td>
+						<label>
+							<input type="checkbox" name="swagger_api_auth_schemes[]" value="basic" <?php checked( in_array( 'basic', $swagger_api_auth_schemes, true ) ); ?>>
+							Basic
+						</label><br>
+						<label>
+							<input type="checkbox" name="swagger_api_auth_schemes[]" value="bearer" <?php checked( in_array( 'bearer', $swagger_api_auth_schemes, true ) ); ?>>
+							Bearer (Authorization header)
+						</label>
+						<p class="description">Which authentication methods appear in the Swagger UI Authorize dialog. Bearer requires a token plugin (e.g. JWT) installed to validate requests.</p>
+					</td>
+				</tr>
 				<tr>
 					<th>API Docs</th>
 					<td>

--- a/tests/test-swaggerauth.php
+++ b/tests/test-swaggerauth.php
@@ -63,4 +63,28 @@ class TestSwaggerAuth extends WP_UnitTestCase {
 		$this->assertNull( SwaggerAuth::parseBasicHeader( 'Basic not-base64-no-colon' ) );
 	}
 
+	public function test_default_emits_only_basic() {
+		delete_option( 'swagger_api_auth_schemes' );
+		$defs = ( new SwaggerAuth() )->appendSwaggerAuth( array() );
+		$this->assertArrayHasKey( 'basic', $defs );
+		$this->assertSame( 'basic', $defs['basic']['type'] );
+		$this->assertArrayNotHasKey( 'bearer', $defs );
+	}
+
+	public function test_both_schemes_emit_both() {
+		update_option( 'swagger_api_auth_schemes', array( 'basic', 'bearer' ) );
+		$defs = ( new SwaggerAuth() )->appendSwaggerAuth( array() );
+		$this->assertSame( 'basic', $defs['basic']['type'] );
+		$this->assertSame( 'apiKey', $defs['bearer']['type'] );
+		$this->assertSame( 'Authorization', $defs['bearer']['name'] );
+		$this->assertSame( 'header', $defs['bearer']['in'] );
+	}
+
+	public function test_bearer_only() {
+		update_option( 'swagger_api_auth_schemes', array( 'bearer' ) );
+		$defs = ( new SwaggerAuth() )->appendSwaggerAuth( array() );
+		$this->assertArrayNotHasKey( 'basic', $defs );
+		$this->assertArrayHasKey( 'bearer', $defs );
+	}
+
 }

--- a/tests/test-swaggerauth.php
+++ b/tests/test-swaggerauth.php
@@ -46,4 +46,21 @@ class TestSwaggerAuth extends WP_UnitTestCase {
 		$this->assertFalse( $this->hook_has_swaggerauth( 'rest_authentication_errors' ) );
 	}
 
+	public function test_parse_basic_header_rejects_bearer() {
+		$this->assertNull( SwaggerAuth::parseBasicHeader( 'Bearer eyJhbGciOi.payload.sig' ) );
+	}
+
+	public function test_parse_basic_header_rejects_non_string() {
+		$this->assertNull( SwaggerAuth::parseBasicHeader( null ) );
+	}
+
+	public function test_parse_basic_header_parses_basic() {
+		$value = 'Basic ' . base64_encode( 'alice:s3cr3t' );
+		$this->assertSame( array( 'alice', 's3cr3t' ), SwaggerAuth::parseBasicHeader( $value ) );
+	}
+
+	public function test_parse_basic_header_rejects_malformed_base64() {
+		$this->assertNull( SwaggerAuth::parseBasicHeader( 'Basic not-base64-no-colon' ) );
+	}
+
 }

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: WP API SwaggerUI
  * Description: WordPress REST API with Swagger UI.
- * Version:     2.0.3
+ * Version:     2.1.0
  * Author:      Agus Suroyo
  * Requires PHP: 7.4
  * License:     GPL v2 or later

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -79,10 +79,15 @@ class WP_API_SwaggerUI
             'tags' => [],
             'schemes' => $this->getSchemes(),
             'paths' => $this->getPaths(),
-            // Cast to object so an empty set encodes as the Swagger 2.0 map `{}`
-            // instead of the JSON array `[]` (invalid securityDefinitions).
-            'securityDefinitions' => (object) $this->securityDefinitions()
         );
+
+        // Only advertise securityDefinitions when a scheme is enabled. Omitting
+        // the key (rather than emitting an empty map) keeps /schema valid Swagger
+        // 2.0 and stops Swagger UI rendering a stray, empty Authorize dialog.
+        $securityDefinitions = $this->securityDefinitions();
+        if (!empty($securityDefinitions)) {
+            $response['securityDefinitions'] = $securityDefinitions;
+        }
 
         wp_send_json($response);
     }

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -79,7 +79,9 @@ class WP_API_SwaggerUI
             'tags' => [],
             'schemes' => $this->getSchemes(),
             'paths' => $this->getPaths(),
-            'securityDefinitions' => $this->securityDefinitions()
+            // Cast to object so an empty set encodes as the Swagger 2.0 map `{}`
+            // instead of the JSON array `[]` (invalid securityDefinitions).
+            'securityDefinitions' => (object) $this->securityDefinitions()
         );
 
         wp_send_json($response);


### PR DESCRIPTION
Adds Bearer token support to the Swagger UI docs, resolving #11.

### What this does
- Adds **Bearer (`Authorization` header)** as a scheme in the Swagger UI **Authorize** dialog, alongside the existing Basic auth.
- Adds a small setting (Settings → Swagger) to choose which schemes appear: Basic, Bearer, or both. Bearer is **off by default**.
- Fixes a latent bug where a Bearer token arriving via `REDIRECT_HTTP_AUTHORIZATION` (Apache mod_rewrite passthrough) was misparsed as Basic and could 401 the request on older WordPress.

### Important: this is UI only
The plugin only emits the Swagger 2.0 security definition so Swagger UI attaches the `Authorization: Bearer <token>` header when you hit **Try it out**. **It does not validate Bearer tokens** — that stays with whatever token plugin the site runs (e.g. *JWT Authentication for WP REST API*). That's why Bearer is opt-in: turn it on once you have a validator installed. This plugin stays a docs generator, not an auth provider.

### Notes
- Swagger 2.0 has no native bearer type, so it's represented as `apiKey` in the `Authorization` header — the standard 2.0 form. You type the full `Bearer <token>` value in the Authorize box.
- Version bumped to 2.1.0.

### Verification
- 40 unit tests pass (wp-env, PHP 8.3).
- Verified in a real browser: the Authorize dialog shows both Basic and Bearer, and the header is sent on requests.

Closes #11
