### PR TITLE
fix: honor per-route tags override in Swagger output (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ register_rest_route(
         'callback'             => $service->get_callback(),
         'summary'              => 'Find pet by ID',
         'description'          => 'Returns a single pet',
+        'tags'                 => ['Pets'],
         'produces'             => ['application/json', 'application/xml'],
         'responses'            => [
             '200' => [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/agussuroyo
 Tags: swaggerui, wp swaggerui, wp rest api, wp swagger rest api, swaggerui rest api, swagger rest api, wp swagger, api, swagger, rest api
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -36,6 +36,9 @@ This plugin can be installed directly from your site.
 2. Options to choose namespace Rest API
 
 == Changelog ==
+
+= 2.1.1 =
+* Fix per-route `tags` override being ignored in the generated Swagger docs
 
 = 2.1.0 =
 * Add Bearer token (Authorization header) support in the Swagger UI Authorize dialog

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -110,12 +110,35 @@ class TestSwaggerUI extends WP_UnitTestCase {
 
 	public function test_getResponses() {
 		$responses = $this->ui->getResponses( '/sample/{id}' );
-		
+
 		$this->assertTrue( is_array( $responses ) );
-		
+
 		$this->assertArrayHasKey( '200', $responses );
 		$this->assertArrayHasKey( '400', $responses );
 		$this->assertArrayHasKey( '404', $responses );
+	}
+
+	public function test_getMethodsFromArgs_custom_tags() {
+		$args = [
+			[
+				'methods'      => [ 'GET' => true ],
+				'tags'         => [ 'Pets' ],
+				'accept_json'  => false,
+			],
+		];
+		$methods = $this->ui->getMethodsFromArgs( '/pets', '/wp/v2/pets', $args );
+		$this->assertEquals( [ 'Pets' ], $methods['get']['tags'] );
+	}
+
+	public function test_getMethodsFromArgs_default_tags() {
+		$args = [
+			[
+				'methods'      => [ 'GET' => true ],
+				'accept_json'  => false,
+			],
+		];
+		$methods = $this->ui->getMethodsFromArgs( '/pets', '/wp/v2/pets', $args );
+		$this->assertEquals( [ 'pets' ], $methods['get']['tags'] );
 	}
 
 }

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: WP API SwaggerUI
  * Description: WordPress REST API with Swagger UI.
- * Version:     2.1.0
+ * Version:     2.1.1
  * Author:      Agus Suroyo
  * Requires PHP: 7.4
  * License:     GPL v2 or later

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -241,17 +241,13 @@ class WP_API_SwaggerUI
                     $consumes[] = ['application/json'];
                 }
 
-                if (isset($args['tags']) && is_array($args['tags'])) {
-                    $tags = $args['tags'];
-                }
-
                 $responses =$this->getResponses($methodEndpoint);
                 if (isset($arg['responses'])) {
                     $responses = $arg['responses'];
                 }
 
                 $conf = array(
-                    'tags' => $tags,
+                    'tags' => isset($arg['tags']) ? (array) $arg['tags'] : $tags,
                     'summary' => isset($arg['summary']) ? $arg['summary'] : '',
                     'description' => isset($arg['description']) ? $arg['description'] : '',
                     'consumes' => $consumes,


### PR DESCRIPTION
Fixes #17.

## Problem

Per-route Swagger `tags` override never worked. `getMethodsFromArgs()` read the override from `$args` (the whole method-group array) instead of `$arg` (the current method group), so `isset($args['tags'])` was never true. `tags` was the only doc field not overridable per route — `summary`, `description`, `produces`, `responses` all already read from `$arg`.

## Fix

- Delete the dead `$args['tags']` block.
- Read `tags` in the `$conf` array like its siblings, falling back to the auto-derived first-path-segment default:

```php
'tags' => isset($arg['tags']) ? (array) $arg['tags'] : $tags,
```

The `(array)` cast accepts a plain string (`'tags' => 'Pets'`) as well as an array.

## Behavior

- `'tags' => ['Pets']` → grouped under **Pets**.
- Multiple tags → operation appears under each group.
- Unset or `null` → auto default (first path segment), unchanged.

## Verification

- Added `test_getMethodsFromArgs_custom_tags` and `test_getMethodsFromArgs_default_tags`. Full suite: 42 passing.
- Manually verified in Swagger UI (wp-env): valid, multi-tag, string-cast, unset, null, empty-array, and numeric inputs all render without JS errors. Empty array falls into Swagger's "default" group; numeric tags render harmlessly (dev misuse, not guarded — consistent with other doc fields).

## Scope

Operation-level tags only. Top-level `tags` list (descriptions + ordering) is optional polish and intentionally out of scope.