### PR TITLE
feat: support OpenAPI 3.0.3 output alongside Swagger 2.0 (#7)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/agussuroyo
 Tags: swaggerui, wp swaggerui, wp rest api, wp swagger rest api, swaggerui rest api, swagger rest api, wp swagger, api, swagger, rest api
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 2.1.1
+Stable tag: 2.2.0
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -36,6 +36,10 @@ This plugin can be installed directly from your site.
 2. Options to choose namespace Rest API
 
 == Changelog ==
+
+= 2.2.0 =
+* Add OpenAPI 3.0.3 output, selectable in Settings → Swagger (default stays Swagger 2.0, so existing installs are unchanged)
+* Add a setting to include or omit the site contact email in the generated schema
 
 = 2.1.1 =
 * Fix per-route `tags` override being ignored in the generated Swagger docs

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -12,7 +12,7 @@ class Spec20Formatter implements SwaggerSpecFormatter {
 	}
 
 	public function format(array $spec): array {
-		return $spec; // intermediate is already 2.0-shaped
+		return array( 'swagger' => $this->version() ) + $spec;
 	}
 }
 
@@ -23,9 +23,9 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	}
 
 	public function format(array $spec): array {
-		$spec['openapi'] = '3.0.3';
 		$spec['servers'] = $this->mapServers( $spec );
-		unset( $spec['swagger'], $spec['host'], $spec['basePath'], $spec['schemes'] );
+		unset( $spec['host'], $spec['basePath'], $spec['schemes'] );
+		$spec = array( 'openapi' => $this->version() ) + $spec;
 
 		if ( isset( $spec['securityDefinitions'] ) ) {
 			$schemes = $this->mapSecuritySchemes( $spec['securityDefinitions'] );
@@ -94,21 +94,21 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	}
 
 	private function mapParameter(array $param): array {
-		$schema = ( isset( $param['schema'] ) && is_array( $param['schema'] ) ) ? $param['schema'] : array();
-
-		foreach ( array( 'type', 'format', 'items', 'minimum', 'maximum' ) as $key ) {
-			if ( isset( $param[ $key ] ) && ! isset( $schema[ $key ] ) ) {
-				$schema[ $key ] = $param[ $key ];
-			}
-			unset( $param[ $key ] );
-		}
-
 		if ( isset( $param['collectionFormat'] ) ) {
 			if ( 'multi' === $param['collectionFormat'] ) {
 				$param['style']   = 'form';
 				$param['explode'] = true;
 			}
 			unset( $param['collectionFormat'] );
+		}
+
+		$keep   = array( 'name', 'in', 'description', 'required', 'deprecated', 'allowEmptyValue', 'style', 'explode', 'schema' );
+		$schema = $this->extractSchema( $param, $keep );
+
+		foreach ( array_keys( $param ) as $key ) {
+			if ( ! in_array( $key, $keep, true ) ) {
+				unset( $param[ $key ] );
+			}
 		}
 
 		if ( ! empty( $schema ) ) {
@@ -118,18 +118,26 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		return $param;
 	}
 
+	private function extractSchema(array $param, array $keep): array {
+		$schema = ( isset( $param['schema'] ) && is_array( $param['schema'] ) ) ? $param['schema'] : array();
+		foreach ( array_keys( $param ) as $key ) {
+			if ( in_array( $key, $keep, true ) ) {
+				continue;
+			}
+			if ( ! isset( $schema[ $key ] ) ) {
+				$schema[ $key ] = $param[ $key ];
+			}
+		}
+		return $schema;
+	}
+
 	private function mapFormDataBody(array $form_data): array {
 		$properties = array();
 		$required   = array();
 
 		foreach ( $form_data as $param ) {
 			$name   = $param['name'];
-			$schema = ( isset( $param['schema'] ) && is_array( $param['schema'] ) ) ? $param['schema'] : array();
-			foreach ( array( 'type', 'format', 'items', 'minimum', 'maximum' ) as $key ) {
-				if ( isset( $param[ $key ] ) && ! isset( $schema[ $key ] ) ) {
-					$schema[ $key ] = $param[ $key ];
-				}
-			}
+			$schema = $this->extractSchema( $param, array( 'name', 'in', 'required', 'schema' ) );
 			if ( empty( $schema ) ) {
 				$schema = array( 'type' => 'string' );
 			}

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -158,11 +158,11 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			if ( 'basic' === $type ) {
 				$out[ $key ] = array( 'type' => 'http', 'scheme' => 'basic' );
 			} elseif ( 'bearer' === $key ) {
-				$scheme = array( 'type' => 'http', 'scheme' => 'bearer' );
-				if ( isset( $def['description'] ) ) {
-					$scheme['description'] = $def['description'];
-				}
-				$out[ $key ] = $scheme;
+				$out[ $key ] = array(
+					'type'        => 'http',
+					'scheme'      => 'bearer',
+					'description' => 'Enter your token; the "Bearer" prefix is added automatically.',
+				);
 			} else {
 				$out[ $key ] = $def; // already valid 3.0 (e.g. apiKey)
 			}

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -35,7 +35,73 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			unset( $spec['securityDefinitions'] );
 		}
 
+		if ( isset( $spec['paths'] ) ) {
+			$spec['paths'] = $this->mapPaths( $spec['paths'] );
+		}
+
 		return $spec;
+	}
+
+	private function mapPaths(array $paths): array {
+		$out = array();
+		foreach ( $paths as $path => $methods ) {
+			$out[ $path ] = array();
+			foreach ( $methods as $method => $operation ) {
+				$out[ $path ][ $method ] = $this->mapOperation( $operation );
+			}
+		}
+
+		return $out;
+	}
+
+	private function mapOperation(array $op): array {
+		unset( $op['consumes'], $op['produces'] );
+
+		if ( ! isset( $op['parameters'] ) ) {
+			return $op;
+		}
+
+		$parameters = array();
+		foreach ( $op['parameters'] as $param ) {
+			$in = isset( $param['in'] ) ? $param['in'] : 'query';
+			if ( 'formData' === $in || 'body' === $in ) {
+				continue; // handled in Task 5
+			}
+			$parameters[] = $this->mapParameter( $param );
+		}
+
+		if ( empty( $parameters ) ) {
+			unset( $op['parameters'] );
+		} else {
+			$op['parameters'] = $parameters;
+		}
+
+		return $op;
+	}
+
+	private function mapParameter(array $param): array {
+		$schema = ( isset( $param['schema'] ) && is_array( $param['schema'] ) ) ? $param['schema'] : array();
+
+		foreach ( array( 'type', 'format', 'items', 'minimum', 'maximum' ) as $key ) {
+			if ( isset( $param[ $key ] ) && ! isset( $schema[ $key ] ) ) {
+				$schema[ $key ] = $param[ $key ];
+			}
+			unset( $param[ $key ] );
+		}
+
+		if ( isset( $param['collectionFormat'] ) ) {
+			if ( 'multi' === $param['collectionFormat'] ) {
+				$param['style']   = 'form';
+				$param['explode'] = true;
+			}
+			unset( $param['collectionFormat'] );
+		}
+
+		if ( ! empty( $schema ) ) {
+			$param['schema'] = $schema;
+		}
+
+		return $param;
 	}
 
 	private function mapSecuritySchemes(array $defs): array {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -187,17 +187,23 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	private function mapFormDataBody(array $form_data, array $media): array {
 		$properties = array();
 		$required   = array();
+		$encoding   = array();
 
 		foreach ( $form_data as $param ) {
-			$name   = $param['name'];
-			$schema = $this->extractSchema( $param, array( 'name', 'in', 'required', 'schema', 'collectionFormat' ) );
-			$schema = $this->normalizeFileSchema( $schema );
+			$name              = $param['name'];
+			$collection_format = isset( $param['collectionFormat'] ) ? $param['collectionFormat'] : null;
+			$schema            = $this->extractSchema( $param, array( 'name', 'in', 'required', 'schema', 'collectionFormat' ) );
+			$schema            = $this->normalizeFileSchema( $schema );
 			if ( empty( $schema ) ) {
 				$schema = array( 'type' => 'string' );
 			}
 			$properties[ $name ] = $schema;
 			if ( ! empty( $param['required'] ) ) {
 				$required[] = $name;
+			}
+			if ( isset( $schema['type'] ) && 'array' === $schema['type'] ) {
+				$style             = $this->arrayStyle( $collection_format, 'query' );
+				$encoding[ $name ] = array( 'style' => $style[0], 'explode' => $style[1] );
 			}
 		}
 
@@ -208,7 +214,11 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 
 		$content = array();
 		foreach ( $media as $m ) {
-			$content[ $m ] = array( 'schema' => $body );
+			$entry = array( 'schema' => $body );
+			if ( ! empty( $encoding ) ) {
+				$entry['encoding'] = $encoding;
+			}
+			$content[ $m ] = $entry;
 		}
 
 		$request_body = array( 'content' => $content );

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -27,7 +27,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		unset( $spec['host'], $spec['basePath'], $spec['schemes'] );
 		$spec = array( 'openapi' => $this->version() ) + $spec;
 
-		if ( isset( $spec['securityDefinitions'] ) ) {
+		if ( isset( $spec['securityDefinitions'] ) && is_array( $spec['securityDefinitions'] ) ) {
 			$schemes = $this->mapSecuritySchemes( $spec['securityDefinitions'] );
 			if ( ! empty( $schemes ) ) {
 				$spec['components'] = array( 'securitySchemes' => $schemes );
@@ -59,7 +59,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		$consumes = ! empty( $op['consumes'] ) ? (array) $op['consumes'] : array();
 		unset( $op['consumes'], $op['produces'] );
 
-		if ( isset( $op['responses'] ) ) {
+		if ( isset( $op['responses'] ) && is_array( $op['responses'] ) ) {
 			$op['responses'] = $this->mapResponses( $op['responses'], $produces );
 		}
 
@@ -195,6 +195,9 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		$encoding   = array();
 
 		foreach ( $form_data as $param ) {
+			if ( ! isset( $param['name'] ) || '' === $param['name'] ) {
+				continue;
+			}
 			$name              = $param['name'];
 			$collection_format = isset( $param['collectionFormat'] ) ? $param['collectionFormat'] : null;
 			$schema            = $this->extractSchema( $param, array( 'name', 'in', 'required', 'schema', 'collectionFormat' ) );
@@ -250,7 +253,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			$type = isset( $def['type'] ) ? $def['type'] : '';
 			if ( 'basic' === $type ) {
 				$out[ $key ] = array( 'type' => 'http', 'scheme' => 'basic' );
-			} elseif ( 'bearer' === $key ) {
+			} elseif ( 'bearer' === $key && 'oauth2' !== $type ) {
 				$out[ $key ] = array(
 					'type'        => 'http',
 					'scheme'      => 'bearer',
@@ -284,7 +287,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		if ( isset( $def['tokenUrl'] ) ) {
 			$flow['tokenUrl'] = $def['tokenUrl'];
 		}
-		$flow['scopes'] = isset( $def['scopes'] ) ? $def['scopes'] : array();
+		$flow['scopes'] = ( isset( $def['scopes'] ) && ! empty( $def['scopes'] ) ) ? $def['scopes'] : new \stdClass();
 
 		$scheme = array(
 			'type'  => 'oauth2',

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -56,6 +56,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 
 	private function mapOperation(array $op): array {
 		$produces = ! empty( $op['produces'] ) ? (array) $op['produces'] : array( 'application/json' );
+		$consumes = ! empty( $op['consumes'] ) ? (array) $op['consumes'] : array();
 		unset( $op['consumes'], $op['produces'] );
 
 		if ( isset( $op['responses'] ) ) {
@@ -90,11 +91,15 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		}
 
 		if ( ! empty( $form_data ) ) {
-			$op['requestBody'] = $this->mapFormDataBody( $form_data );
+			$media             = ! empty( $consumes ) ? $consumes : array( 'application/x-www-form-urlencoded' );
+			$op['requestBody'] = $this->mapFormDataBody( $form_data, $media );
 		} elseif ( null !== $body ) {
-			$request_body = array(
-				'content' => array( 'application/json' => array( 'schema' => $body ) ),
-			);
+			$media   = ! empty( $consumes ) ? $consumes : array( 'application/json' );
+			$content = array();
+			foreach ( $media as $m ) {
+				$content[ $m ] = array( 'schema' => $body );
+			}
+			$request_body = array( 'content' => $content );
 			if ( $body_required ) {
 				$request_body['required'] = true;
 			}
@@ -158,13 +163,14 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		return $schema;
 	}
 
-	private function mapFormDataBody(array $form_data): array {
+	private function mapFormDataBody(array $form_data, array $media): array {
 		$properties = array();
 		$required   = array();
 
 		foreach ( $form_data as $param ) {
 			$name   = $param['name'];
 			$schema = $this->extractSchema( $param, array( 'name', 'in', 'required', 'schema', 'collectionFormat' ) );
+			$schema = $this->normalizeFileSchema( $schema );
 			if ( empty( $schema ) ) {
 				$schema = array( 'type' => 'string' );
 			}
@@ -179,11 +185,20 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			$body['required'] = $required;
 		}
 
-		return array(
-			'content' => array(
-				'application/x-www-form-urlencoded' => array( 'schema' => $body ),
-			),
-		);
+		$content = array();
+		foreach ( $media as $m ) {
+			$content[ $m ] = array( 'schema' => $body );
+		}
+
+		return array( 'content' => $content );
+	}
+
+	private function normalizeFileSchema(array $schema): array {
+		if ( isset( $schema['type'] ) && 'file' === $schema['type'] ) {
+			$schema['type']   = 'string';
+			$schema['format'] = 'binary';
+		}
+		return $schema;
 	}
 
 	private function mapSecuritySchemes(array $defs): array {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -1,0 +1,36 @@
+<?php
+
+interface SwaggerSpecFormatter {
+	public function version(): string;
+	public function format(array $spec): array;
+}
+
+class Spec20Formatter implements SwaggerSpecFormatter {
+
+	public function version(): string {
+		return '2.0';
+	}
+
+	public function format(array $spec): array {
+		return $spec; // intermediate is already 2.0-shaped
+	}
+}
+
+class SwaggerSpecRegistry {
+
+	private static function map(): array {
+		return array(
+			'2.0' => Spec20Formatter::class,
+		);
+	}
+
+	public static function versions(): array {
+		return array_keys( self::map() );
+	}
+
+	public static function forVersion( string $version ): SwaggerSpecFormatter {
+		$map   = self::map();
+		$class = isset( $map[ $version ] ) ? $map[ $version ] : Spec20Formatter::class;
+		return new $class();
+	}
+}

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -137,7 +137,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 
 		foreach ( $form_data as $param ) {
 			$name   = $param['name'];
-			$schema = $this->extractSchema( $param, array( 'name', 'in', 'required', 'schema' ) );
+			$schema = $this->extractSchema( $param, array( 'name', 'in', 'required', 'schema', 'collectionFormat' ) );
 			if ( empty( $schema ) ) {
 				$schema = array( 'type' => 'string' );
 			}

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -27,7 +27,35 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		$spec['servers'] = $this->mapServers( $spec );
 		unset( $spec['swagger'], $spec['host'], $spec['basePath'], $spec['schemes'] );
 
+		if ( isset( $spec['securityDefinitions'] ) ) {
+			$schemes = $this->mapSecuritySchemes( $spec['securityDefinitions'] );
+			if ( ! empty( $schemes ) ) {
+				$spec['components'] = array( 'securitySchemes' => $schemes );
+			}
+			unset( $spec['securityDefinitions'] );
+		}
+
 		return $spec;
+	}
+
+	private function mapSecuritySchemes(array $defs): array {
+		$out = array();
+		foreach ( $defs as $key => $def ) {
+			$type = isset( $def['type'] ) ? $def['type'] : '';
+			if ( 'basic' === $type ) {
+				$out[ $key ] = array( 'type' => 'http', 'scheme' => 'basic' );
+			} elseif ( 'bearer' === $key ) {
+				$scheme = array( 'type' => 'http', 'scheme' => 'bearer' );
+				if ( isset( $def['description'] ) ) {
+					$scheme['description'] = $def['description'];
+				}
+				$out[ $key ] = $scheme;
+			} else {
+				$out[ $key ] = $def; // already valid 3.0 (e.g. apiKey)
+			}
+		}
+
+		return $out;
 	}
 
 	private function mapServers(array $spec): array {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -55,22 +55,29 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	}
 
 	private function mapOperation(array $op): array {
+		$produces = ! empty( $op['produces'] ) ? (array) $op['produces'] : array( 'application/json' );
 		unset( $op['consumes'], $op['produces'] );
+
+		if ( isset( $op['responses'] ) ) {
+			$op['responses'] = $this->mapResponses( $op['responses'], $produces );
+		}
 
 		if ( ! isset( $op['parameters'] ) ) {
 			return $op;
 		}
 
-		$parameters = array();
-		$form_data  = array();
-		$body       = null;
+		$parameters    = array();
+		$form_data     = array();
+		$body          = null;
+		$body_required = false;
 
 		foreach ( $op['parameters'] as $param ) {
 			$in = isset( $param['in'] ) ? $param['in'] : 'query';
 			if ( 'formData' === $in ) {
 				$form_data[] = $param;
 			} elseif ( 'body' === $in ) {
-				$body = isset( $param['schema'] ) ? $param['schema'] : array( 'type' => 'object' );
+				$body          = isset( $param['schema'] ) ? $param['schema'] : array( 'type' => 'object' );
+				$body_required = ! empty( $param['required'] );
 			} else {
 				$parameters[] = $this->mapParameter( $param );
 			}
@@ -85,12 +92,32 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		if ( ! empty( $form_data ) ) {
 			$op['requestBody'] = $this->mapFormDataBody( $form_data );
 		} elseif ( null !== $body ) {
-			$op['requestBody'] = array(
+			$request_body = array(
 				'content' => array( 'application/json' => array( 'schema' => $body ) ),
 			);
+			if ( $body_required ) {
+				$request_body['required'] = true;
+			}
+			$op['requestBody'] = $request_body;
 		}
 
 		return $op;
+	}
+
+	private function mapResponses(array $responses, array $produces): array {
+		foreach ( $responses as $code => $response ) {
+			if ( is_array( $response ) && isset( $response['schema'] ) ) {
+				$schema = $response['schema'];
+				unset( $response['schema'] );
+				$content = array();
+				foreach ( $produces as $media ) {
+					$content[ $media ] = array( 'schema' => $schema );
+				}
+				$response['content'] = $content;
+				$responses[ $code ]  = $response;
+			}
+		}
+		return $responses;
 	}
 
 	private function mapParameter(array $param): array {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -96,11 +96,8 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			$media             = ! empty( $consumes ) ? $consumes : array( 'application/x-www-form-urlencoded' );
 			$op['requestBody'] = $this->mapFormDataBody( $form_data, $media );
 		} elseif ( null !== $body ) {
-			$media   = ! empty( $consumes ) ? $consumes : array( 'application/json' );
-			$content = array();
-			foreach ( $media as $m ) {
-				$content[ $m ] = array( 'schema' => $body );
-			}
+			$media        = ! empty( $consumes ) ? $consumes : array( 'application/json' );
+			$content      = $this->contentFor( $media, $body );
 			$request_body = array( 'content' => $content );
 			if ( null !== $body_description ) {
 				$request_body['description'] = $body_description;
@@ -116,16 +113,32 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 
 	private function mapResponses(array $responses, array $produces): array {
 		foreach ( $responses as $code => $response ) {
-			if ( is_array( $response ) && isset( $response['schema'] ) ) {
-				$schema = $response['schema'];
-				unset( $response['schema'] );
-				$content = array();
-				foreach ( $produces as $media ) {
-					$content[ $media ] = array( 'schema' => $schema );
-				}
-				$response['content'] = $content;
-				$responses[ $code ]  = $response;
+			if ( ! is_array( $response ) ) {
+				continue;
 			}
+			$schema   = isset( $response['schema'] ) ? $response['schema'] : null;
+			$examples = ( isset( $response['examples'] ) && is_array( $response['examples'] ) ) ? $response['examples'] : array();
+			if ( null === $schema && empty( $examples ) ) {
+				continue;
+			}
+			unset( $response['schema'], $response['examples'] );
+			$content = array();
+			foreach ( $produces as $m ) {
+				$entry = array();
+				if ( null !== $schema ) {
+					$entry['schema'] = $schema;
+				}
+				if ( isset( $examples[ $m ] ) ) {
+					$entry['example'] = $examples[ $m ];
+				}
+				if ( ! empty( $entry ) ) {
+					$content[ $m ] = $entry;
+				}
+			}
+			if ( ! empty( $content ) ) {
+				$response['content'] = $content;
+			}
+			$responses[ $code ] = $response;
 		}
 		return $responses;
 	}
@@ -186,7 +199,18 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 				$schema[ $key ] = $param[ $key ];
 			}
 		}
+		if ( isset( $schema['type'] ) && 'array' === $schema['type'] && ! isset( $schema['items'] ) ) {
+			$schema['items'] = array( 'type' => 'string' );
+		}
 		return $schema;
+	}
+
+	private function contentFor(array $media, array $schema): array {
+		$content = array();
+		foreach ( $media as $m ) {
+			$content[ $m ] = array( 'schema' => $schema );
+		}
+		return $content;
 	}
 
 	private function mapFormDataBody(array $form_data, array $media): array {
@@ -222,13 +246,13 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 
 		$form_media = array( 'application/x-www-form-urlencoded', 'multipart/form-data' );
 
-		$content = array();
-		foreach ( $media as $m ) {
-			$entry = array( 'schema' => $body );
-			if ( ! empty( $encoding ) && in_array( $m, $form_media, true ) ) {
-				$entry['encoding'] = $encoding;
+		$content = $this->contentFor( $media, $body );
+		if ( ! empty( $encoding ) ) {
+			foreach ( $form_media as $fm ) {
+				if ( isset( $content[ $fm ] ) ) {
+					$content[ $fm ]['encoding'] = $encoding;
+				}
 			}
-			$content[ $m ] = $entry;
 		}
 
 		$request_body = array( 'content' => $content );

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -212,10 +212,12 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			$body['required'] = $required;
 		}
 
+		$form_media = array( 'application/x-www-form-urlencoded', 'multipart/form-data' );
+
 		$content = array();
 		foreach ( $media as $m ) {
 			$entry = array( 'schema' => $body );
-			if ( ! empty( $encoding ) ) {
+			if ( ! empty( $encoding ) && in_array( $m, $form_media, true ) ) {
 				$entry['encoding'] = $encoding;
 			}
 			$content[ $m ] = $entry;

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -143,7 +143,8 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		}
 
 		if ( isset( $schema['type'] ) && 'array' === $schema['type'] ) {
-			$serialization    = $this->arrayStyle( $collection_format );
+			$in               = isset( $param['in'] ) ? $param['in'] : 'query';
+			$serialization    = $this->arrayStyle( $collection_format, $in );
 			$param['style']   = $serialization[0];
 			$param['explode'] = $serialization[1];
 		}
@@ -151,7 +152,11 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		return $param;
 	}
 
-	private function arrayStyle($collection_format): array {
+	private function arrayStyle($collection_format, string $in): array {
+		if ( 'path' === $in || 'header' === $in ) {
+			// OAS3: path/header array parameters use 'simple' (comma-separated).
+			return array( 'simple', false );
+		}
 		switch ( $collection_format ) {
 			case 'multi':
 				return array( 'form', true );
@@ -234,12 +239,44 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 					'scheme'      => 'bearer',
 					'description' => 'Enter your token; the "Bearer" prefix is added automatically.',
 				);
+			} elseif ( 'oauth2' === $type ) {
+				$out[ $key ] = $this->mapOauth2( $def );
 			} else {
 				$out[ $key ] = $def; // already valid 3.0 (e.g. apiKey)
 			}
 		}
 
 		return $out;
+	}
+
+	private function mapOauth2(array $def): array {
+		$flow_names = array(
+			'implicit'    => 'implicit',
+			'password'    => 'password',
+			'application' => 'clientCredentials',
+			'accessCode'  => 'authorizationCode',
+		);
+		$flow_key = ( isset( $def['flow'] ) && isset( $flow_names[ $def['flow'] ] ) )
+			? $flow_names[ $def['flow'] ]
+			: 'implicit';
+
+		$flow = array();
+		if ( isset( $def['authorizationUrl'] ) ) {
+			$flow['authorizationUrl'] = $def['authorizationUrl'];
+		}
+		if ( isset( $def['tokenUrl'] ) ) {
+			$flow['tokenUrl'] = $def['tokenUrl'];
+		}
+		$flow['scopes'] = isset( $def['scopes'] ) ? $def['scopes'] : array();
+
+		$scheme = array(
+			'type'  => 'oauth2',
+			'flows' => array( $flow_key => $flow ),
+		);
+		if ( isset( $def['description'] ) ) {
+			$scheme['description'] = $def['description'];
+		}
+		return $scheme;
 	}
 
 	private function mapServers(array $spec): array {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -126,13 +126,8 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	}
 
 	private function mapParameter(array $param): array {
-		if ( isset( $param['collectionFormat'] ) ) {
-			if ( 'multi' === $param['collectionFormat'] ) {
-				$param['style']   = 'form';
-				$param['explode'] = true;
-			}
-			unset( $param['collectionFormat'] );
-		}
+		$collection_format = isset( $param['collectionFormat'] ) ? $param['collectionFormat'] : null;
+		unset( $param['collectionFormat'] );
 
 		$keep   = array( 'name', 'in', 'description', 'required', 'deprecated', 'allowEmptyValue', 'style', 'explode', 'schema' );
 		$schema = $this->extractSchema( $param, $keep );
@@ -147,7 +142,28 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			$param['schema'] = $schema;
 		}
 
+		if ( isset( $schema['type'] ) && 'array' === $schema['type'] ) {
+			$serialization    = $this->arrayStyle( $collection_format );
+			$param['style']   = $serialization[0];
+			$param['explode'] = $serialization[1];
+		}
+
 		return $param;
+	}
+
+	private function arrayStyle($collection_format): array {
+		switch ( $collection_format ) {
+			case 'multi':
+				return array( 'form', true );
+			case 'ssv':
+				return array( 'spaceDelimited', false );
+			case 'pipes':
+				return array( 'pipeDelimited', false );
+			case 'csv':
+			case 'tsv': // no native OAS3 tsv; closest is comma (form/false)
+			default:    // Swagger 2.0 default is csv
+				return array( 'form', false );
+		}
 	}
 
 	private function extractSchema(array $param, array $keep): array {
@@ -190,7 +206,12 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			$content[ $m ] = array( 'schema' => $body );
 		}
 
-		return array( 'content' => $content );
+		$request_body = array( 'content' => $content );
+		if ( ! empty( $required ) ) {
+			$request_body['required'] = true;
+		}
+
+		return $request_body;
 	}
 
 	private function normalizeFileSchema(array $schema): array {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -62,18 +62,32 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		}
 
 		$parameters = array();
+		$form_data  = array();
+		$body       = null;
+
 		foreach ( $op['parameters'] as $param ) {
 			$in = isset( $param['in'] ) ? $param['in'] : 'query';
-			if ( 'formData' === $in || 'body' === $in ) {
-				continue; // handled in Task 5
+			if ( 'formData' === $in ) {
+				$form_data[] = $param;
+			} elseif ( 'body' === $in ) {
+				$body = isset( $param['schema'] ) ? $param['schema'] : array( 'type' => 'object' );
+			} else {
+				$parameters[] = $this->mapParameter( $param );
 			}
-			$parameters[] = $this->mapParameter( $param );
 		}
 
 		if ( empty( $parameters ) ) {
 			unset( $op['parameters'] );
 		} else {
 			$op['parameters'] = $parameters;
+		}
+
+		if ( ! empty( $form_data ) ) {
+			$op['requestBody'] = $this->mapFormDataBody( $form_data );
+		} elseif ( null !== $body ) {
+			$op['requestBody'] = array(
+				'content' => array( 'application/json' => array( 'schema' => $body ) ),
+			);
 		}
 
 		return $op;
@@ -102,6 +116,39 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		}
 
 		return $param;
+	}
+
+	private function mapFormDataBody(array $form_data): array {
+		$properties = array();
+		$required   = array();
+
+		foreach ( $form_data as $param ) {
+			$name   = $param['name'];
+			$schema = ( isset( $param['schema'] ) && is_array( $param['schema'] ) ) ? $param['schema'] : array();
+			foreach ( array( 'type', 'format', 'items', 'minimum', 'maximum' ) as $key ) {
+				if ( isset( $param[ $key ] ) && ! isset( $schema[ $key ] ) ) {
+					$schema[ $key ] = $param[ $key ];
+				}
+			}
+			if ( empty( $schema ) ) {
+				$schema = array( 'type' => 'string' );
+			}
+			$properties[ $name ] = $schema;
+			if ( ! empty( $param['required'] ) ) {
+				$required[] = $name;
+			}
+		}
+
+		$body = array( 'type' => 'object', 'properties' => $properties );
+		if ( ! empty( $required ) ) {
+			$body['required'] = $required;
+		}
+
+		return array(
+			'content' => array(
+				'application/x-www-form-urlencoded' => array( 'schema' => $body ),
+			),
+		);
 	}
 
 	private function mapSecuritySchemes(array $defs): array {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -67,18 +67,20 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			return $op;
 		}
 
-		$parameters    = array();
-		$form_data     = array();
-		$body          = null;
-		$body_required = false;
+		$parameters       = array();
+		$form_data        = array();
+		$body             = null;
+		$body_required    = false;
+		$body_description = null;
 
 		foreach ( $op['parameters'] as $param ) {
 			$in = isset( $param['in'] ) ? $param['in'] : 'query';
 			if ( 'formData' === $in ) {
 				$form_data[] = $param;
 			} elseif ( 'body' === $in ) {
-				$body          = isset( $param['schema'] ) ? $param['schema'] : array( 'type' => 'object' );
-				$body_required = ! empty( $param['required'] );
+				$body             = isset( $param['schema'] ) ? $param['schema'] : array( 'type' => 'object' );
+				$body_required    = ! empty( $param['required'] );
+				$body_description = ( isset( $param['description'] ) && '' !== $param['description'] ) ? $param['description'] : null;
 			} else {
 				$parameters[] = $this->mapParameter( $param );
 			}
@@ -100,6 +102,9 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 				$content[ $m ] = array( 'schema' => $body );
 			}
 			$request_body = array( 'content' => $content );
+			if ( null !== $body_description ) {
+				$request_body['description'] = $body_description;
+			}
 			if ( $body_required ) {
 				$request_body['required'] = true;
 			}

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -16,11 +16,40 @@ class Spec20Formatter implements SwaggerSpecFormatter {
 	}
 }
 
+class Spec30Formatter implements SwaggerSpecFormatter {
+
+	public function version(): string {
+		return '3.0.3';
+	}
+
+	public function format(array $spec): array {
+		$spec['openapi'] = '3.0.3';
+		$spec['servers'] = $this->mapServers( $spec );
+		unset( $spec['swagger'], $spec['host'], $spec['basePath'], $spec['schemes'] );
+
+		return $spec;
+	}
+
+	private function mapServers(array $spec): array {
+		$host     = isset( $spec['host'] ) ? $spec['host'] : '';
+		$basePath = isset( $spec['basePath'] ) ? $spec['basePath'] : '';
+		$schemes  = ! empty( $spec['schemes'] ) ? $spec['schemes'] : array( 'https' );
+
+		$servers = array();
+		foreach ( $schemes as $scheme ) {
+			$servers[] = array( 'url' => $scheme . '://' . $host . $basePath );
+		}
+
+		return $servers;
+	}
+}
+
 class SwaggerSpecRegistry {
 
 	private static function map(): array {
 		return array(
-			'2.0' => Spec20Formatter::class,
+			'2.0'   => Spec20Formatter::class,
+			'3.0.3' => Spec30Formatter::class,
 		);
 	}
 

--- a/swaggersetting.php
+++ b/swaggersetting.php
@@ -24,6 +24,8 @@ class SwaggerSetting {
 				}
 			}
 
+			update_option( 'swagger_api_expose_contact_email', isset( $_POST['swagger_api_expose_contact_email'] ) ? '1' : '0' );
+
 			add_action( 'admin_notices', [ $this, 'notices' ] );
 		}
 	}
@@ -42,6 +44,7 @@ class SwaggerSetting {
 		$data['swagger_api_auth_schemes'] = (array) get_option( 'swagger_api_auth_schemes', array( 'basic' ) );
 		$data['spec_versions']			 = SwaggerSpecRegistry::versions();
 		$data['swagger_api_spec_version'] = get_option( 'swagger_api_spec_version', '2.0' );
+		$data['swagger_api_expose_contact_email'] = get_option( 'swagger_api_expose_contact_email', '1' );
 
 		echo self::template( 'setting', $data );
 	}

--- a/swaggersetting.php
+++ b/swaggersetting.php
@@ -17,6 +17,13 @@ class SwaggerSetting {
 			$schemes = (array) ( isset( $_POST['swagger_api_auth_schemes'] ) ? $_POST['swagger_api_auth_schemes'] : array() );
 			update_option( 'swagger_api_auth_schemes', array_values( array_intersect( array( 'basic', 'bearer' ), $schemes ) ) );
 
+			if ( isset( $_POST['swagger_api_spec_version'] ) ) {
+				$version = sanitize_text_field( $_POST['swagger_api_spec_version'] );
+				if ( in_array( $version, SwaggerSpecRegistry::versions(), true ) ) {
+					update_option( 'swagger_api_spec_version', $version );
+				}
+			}
+
 			add_action( 'admin_notices', [ $this, 'notices' ] );
 		}
 	}
@@ -33,6 +40,8 @@ class SwaggerSetting {
 		$data['namespaces']				 = rest_get_server()->get_namespaces();
 		$data['docs_url']				 = home_url( untrailingslashit( WP_API_SwaggerUI::rewriteBaseApi() ) . '/docs' );
 		$data['swagger_api_auth_schemes'] = (array) get_option( 'swagger_api_auth_schemes', array( 'basic' ) );
+		$data['spec_versions']			 = SwaggerSpecRegistry::versions();
+		$data['swagger_api_spec_version'] = get_option( 'swagger_api_spec_version', '2.0' );
 
 		echo self::template( 'setting', $data );
 	}

--- a/template/setting.php
+++ b/template/setting.php
@@ -33,6 +33,21 @@
 					</td>
 				</tr>
 				<tr>
+					<th>OpenAPI Version</th>
+					<td>
+						<select name="swagger_api_spec_version">
+							<?php
+							foreach ( $spec_versions as $version ) {
+								?>
+								<option value="<?php echo esc_attr( $version ); ?>" <?php selected( $version, $swagger_api_spec_version ); ?>><?php echo esc_html( $version ); ?></option>
+								<?php
+							}
+							?>
+						</select>
+						<p class="description">Schema output format. 2.0 = Swagger 2.0; 3.0.3 = OpenAPI 3.0.3.</p>
+					</td>
+				</tr>
+				<tr>
 					<th>API Docs</th>
 					<td>
 						<a href="<?php echo esc_url( $docs_url ); ?>" target="__blank">Docs URL</a>

--- a/template/setting.php
+++ b/template/setting.php
@@ -48,6 +48,16 @@
 					</td>
 				</tr>
 				<tr>
+					<th>Contact Email</th>
+					<td>
+						<label>
+							<input type="checkbox" name="swagger_api_expose_contact_email" value="1" <?php checked( '1', $swagger_api_expose_contact_email ); ?>>
+							Include the site admin email as the API contact in the schema
+						</label>
+						<p class="description">Uncheck to omit <code>contact.email</code> from the public schema. Developers can still override via the <code>swagger_api_contact_email</code> filter.</p>
+					</td>
+				</tr>
+				<tr>
 					<th>API Docs</th>
 					<td>
 						<a href="<?php echo esc_url( $docs_url ); ?>" target="__blank">Docs URL</a>

--- a/template/setting.php
+++ b/template/setting.php
@@ -1,5 +1,5 @@
 <div class="wrap">
-	<h2><?php echo $page_title; ?></h2>
+	<h2><?php echo esc_html( $page_title ); ?></h2>
 	<form action="" method="post">
 		<?php wp_nonce_field( 'swagger_api_setting' ) ?>
 		<table class="form-table">

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -80,4 +80,83 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$out  = ( new Spec30Formatter() )->format( $spec );
 		$this->assertArrayNotHasKey( 'components', $out );
 	}
+
+	private function specWithParams( array $params, string $method = 'get' ): array {
+		return array(
+			'swagger'  => '2.0',
+			'host'     => 'e.com',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array(
+				'/x' => array(
+					$method => array(
+						'tags'       => array( 'x' ),
+						'consumes'   => array( 'application/x-www-form-urlencoded' ),
+						'produces'   => array( 'application/json' ),
+						'parameters' => $params,
+						'responses'  => array( '200' => array( 'description' => 'OK' ) ),
+					),
+				),
+			),
+		);
+	}
+
+	private function firstOperation( array $out, string $method = 'get' ): array {
+		return $out['paths']['/x'][ $method ];
+	}
+
+	private function firstParam( array $out ): array {
+		return $this->firstOperation( $out )['parameters'][0];
+	}
+
+	public function test_spec30_drops_consumes_produces() {
+		$op = $this->firstOperation( ( new Spec30Formatter() )->format( $this->specWithParams( array() ) ) );
+		$this->assertArrayNotHasKey( 'consumes', $op );
+		$this->assertArrayNotHasKey( 'produces', $op );
+		$this->assertEquals( array( '200' => array( 'description' => 'OK' ) ), $op['responses'] );
+	}
+
+	public function test_spec30_scalar_param_to_schema() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'search', 'in' => 'query', 'description' => '', 'required' => false, 'type' => 'string', 'format' => 'x' ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertArrayNotHasKey( 'type', $param );
+		$this->assertArrayNotHasKey( 'format', $param );
+		$this->assertEquals( array( 'type' => 'string', 'format' => 'x' ), $param['schema'] );
+		$this->assertEquals( 'query', $param['in'] );
+	}
+
+	public function test_spec30_enum_array_param() {
+		$spec  = $this->specWithParams( array(
+			array(
+				'name'             => 'status',
+				'in'               => 'query',
+				'required'         => false,
+				'type'             => 'array',
+				'items'            => array( 'type' => 'string', 'enum' => array( 'a', 'b' ), 'default' => 'a' ),
+				'collectionFormat' => 'multi',
+			),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertArrayNotHasKey( 'collectionFormat', $param );
+		$this->assertEquals( 'form', $param['style'] );
+		$this->assertTrue( $param['explode'] );
+		$this->assertEquals( 'array', $param['schema']['type'] );
+		$this->assertEquals(
+			array( 'type' => 'string', 'enum' => array( 'a', 'b' ), 'default' => 'a' ),
+			$param['schema']['items']
+		);
+	}
+
+	public function test_spec30_preexisting_schema_not_clobbered() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => 'integer', 'schema' => array( 'type' => 'integer', 'format' => 'int64' ) ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( array( 'type' => 'integer', 'format' => 'int64' ), $param['schema'] );
+	}
 }

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -383,6 +383,26 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_spec30_formdata_encoding_only_on_form_media() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'categories', 'in' => 'formData', 'required' => false, 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+		), 'post', array( 'application/x-www-form-urlencoded', 'application/json' ) );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$content = $op['requestBody']['content'];
+		$this->assertArrayHasKey( 'encoding', $content['application/x-www-form-urlencoded'] );
+		$this->assertArrayNotHasKey( 'encoding', $content['application/json'] );
+	}
+
+	public function test_spec30_formdata_multipart_gets_encoding() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'categories', 'in' => 'formData', 'required' => false, 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+		), 'post', array( 'multipart/form-data' ) );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertArrayHasKey( 'encoding', $op['requestBody']['content']['multipart/form-data'] );
+	}
+
 	public function test_spec30_formdata_multiple_consumes() {
 		$spec = $this->specWithParams( array(
 			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -45,4 +45,39 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertSame( array(), $out['tags'] );
 		$this->assertEquals( array( 'title' => 'T' ), $out['info'] );
 	}
+
+	public function test_spec30_security_schemes() {
+		$spec = array(
+			'swagger'             => '2.0',
+			'host'                => 'e.com',
+			'basePath'            => '/wp-json',
+			'schemes'             => array( 'https' ),
+			'securityDefinitions' => array(
+				'basic'  => array( 'type' => 'basic' ),
+				'bearer' => array(
+					'type'        => 'apiKey',
+					'in'          => 'header',
+					'name'        => 'Authorization',
+					'description' => 'x',
+				),
+			),
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$this->assertArrayNotHasKey( 'securityDefinitions', $out );
+		$this->assertEquals(
+			array( 'type' => 'http', 'scheme' => 'basic' ),
+			$out['components']['securitySchemes']['basic']
+		);
+		$this->assertEquals(
+			array( 'type' => 'http', 'scheme' => 'bearer', 'description' => 'x' ),
+			$out['components']['securitySchemes']['bearer']
+		);
+	}
+
+	public function test_spec30_no_security_definitions() {
+		$spec = array( 'swagger' => '2.0', 'host' => 'e.com', 'basePath' => '/wp-json', 'schemes' => array( 'https' ) );
+		$out  = ( new Spec30Formatter() )->format( $spec );
+		$this->assertArrayNotHasKey( 'components', $out );
+	}
 }

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -91,7 +91,7 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'components', $out );
 	}
 
-	private function specWithParams( array $params, string $method = 'get' ): array {
+	private function specWithParams( array $params, string $method = 'get', array $consumes = array( 'application/x-www-form-urlencoded' ) ): array {
 		return array(
 			'host'     => 'e.com',
 			'basePath' => '/wp-json',
@@ -100,7 +100,7 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 				'/x' => array(
 					$method => array(
 						'tags'       => array( 'x' ),
-						'consumes'   => array( 'application/x-www-form-urlencoded' ),
+						'consumes'   => $consumes,
 						'produces'   => array( 'application/json' ),
 						'parameters' => $params,
 						'responses'  => array( '200' => array( 'description' => 'OK' ) ),
@@ -211,7 +211,7 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 	public function test_spec30_body_param_to_json_requestbody() {
 		$spec = $this->specWithParams( array(
 			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'schema' => array( 'type' => 'object' ) ),
-		), 'post' );
+		), 'post', array( 'application/json' ) );
 		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
 
 		$this->assertArrayNotHasKey( 'parameters', $op );
@@ -265,7 +265,7 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 	public function test_spec30_body_required_on_requestbody() {
 		$spec = $this->specWithParams( array(
 			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'schema' => array( 'type' => 'object' ) ),
-		), 'post' );
+		), 'post', array( 'application/json' ) );
 		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
 
 		$this->assertTrue( $op['requestBody']['required'] );
@@ -282,6 +282,59 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
 
 		$this->assertArrayNotHasKey( 'required', $op['requestBody'] );
+	}
+
+	public function test_spec30_formdata_consumes_override() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),
+		), 'post', array( 'application/xml' ) );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertArrayHasKey( 'application/xml', $op['requestBody']['content'] );
+		$this->assertArrayNotHasKey( 'application/x-www-form-urlencoded', $op['requestBody']['content'] );
+		$this->assertEquals(
+			array( 'type' => 'string' ),
+			$op['requestBody']['content']['application/xml']['schema']['properties']['title']
+		);
+	}
+
+	public function test_spec30_formdata_multiple_consumes() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),
+		), 'post', array( 'application/x-www-form-urlencoded', 'multipart/form-data' ) );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$content = $op['requestBody']['content'];
+		$this->assertArrayHasKey( 'application/x-www-form-urlencoded', $content );
+		$this->assertArrayHasKey( 'multipart/form-data', $content );
+		$this->assertEquals(
+			$content['application/x-www-form-urlencoded']['schema'],
+			$content['multipart/form-data']['schema']
+		);
+	}
+
+	public function test_spec30_body_consumes_override() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'schema' => array( 'type' => 'object' ) ),
+		), 'post', array( 'application/xml' ) );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertEquals(
+			array( 'type' => 'object' ),
+			$op['requestBody']['content']['application/xml']['schema']
+		);
+	}
+
+	public function test_spec30_file_param_to_binary() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'file', 'in' => 'formData', 'required' => true, 'type' => 'file' ),
+		), 'post', array( 'multipart/form-data' ) );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertEquals(
+			array( 'type' => 'string', 'format' => 'binary' ),
+			$op['requestBody']['content']['multipart/form-data']['schema']['properties']['file']
+		);
 	}
 
 	public function test_setting_save_whitelists_version() {

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -194,6 +194,20 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertEquals( array( 'title' ), $schema['required'] );
 	}
 
+	public function test_spec30_formdata_drops_collectionformat() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'status', 'in' => 'formData', 'required' => false, 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => array( 'open', 'closed' ) ), 'collectionFormat' => 'multi' ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$property = $op['requestBody']['content']['application/x-www-form-urlencoded']['schema']['properties']['status'];
+		$this->assertEquals(
+			array( 'type' => 'array', 'items' => array( 'type' => 'string', 'enum' => array( 'open', 'closed' ) ) ),
+			$property
+		);
+		$this->assertArrayNotHasKey( 'collectionFormat', $property );
+	}
+
 	public function test_spec30_body_param_to_json_requestbody() {
 		$spec = $this->specWithParams( array(
 			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'schema' => array( 'type' => 'object' ) ),

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -1,0 +1,20 @@
+<?php
+
+class TestSwaggerOpenApi extends WP_UnitTestCase {
+
+	public function test_spec20_passthrough() {
+		$spec = array( 'swagger' => '2.0', 'paths' => array( '/x' => array() ) );
+		$f    = new Spec20Formatter();
+		$this->assertSame( $spec, $f->format( $spec ) );
+		$this->assertEquals( '2.0', $f->version() );
+	}
+
+	public function test_registry_versions_contains_20() {
+		$this->assertContains( '2.0', SwaggerSpecRegistry::versions() );
+	}
+
+	public function test_registry_forVersion_known_and_unknown() {
+		$this->assertInstanceOf( Spec20Formatter::class, SwaggerSpecRegistry::forVersion( '2.0' ) );
+		$this->assertInstanceOf( Spec20Formatter::class, SwaggerSpecRegistry::forVersion( 'bogus' ) );
+	}
+}

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -187,4 +187,26 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 			$op['requestBody']['content']['application/json']['schema']
 		);
 	}
+
+	public function test_setting_save_whitelists_version() {
+		if ( ! class_exists( 'SwaggerSetting' ) ) {
+			require_once dirname( __DIR__ ) . '/swaggersetting.php';
+		}
+
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$setting = new SwaggerSetting();
+
+		$_POST['_wpnonce']                 = wp_create_nonce( 'swagger_api_setting' );
+		$_POST['swagger_api_spec_version'] = '3.0.3';
+		$setting->saveSetting();
+		$this->assertEquals( '3.0.3', get_option( 'swagger_api_spec_version' ) );
+
+		$_POST['swagger_api_spec_version'] = 'bogus';
+		$setting->saveSetting();
+		$this->assertEquals( '3.0.3', get_option( 'swagger_api_spec_version' ), 'invalid value must be rejected' );
+
+		unset( $_POST['_wpnonce'], $_POST['swagger_api_spec_version'] );
+	}
 }

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -230,6 +230,46 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'collectionFormat', $property );
 	}
 
+	public function test_spec30_formdata_csv_array_encoding() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'categories', 'in' => 'formData', 'required' => false, 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$entry = $op['requestBody']['content']['application/x-www-form-urlencoded'];
+		$this->assertEquals(
+			array( 'style' => 'form', 'explode' => false ),
+			$entry['encoding']['categories']
+		);
+		$this->assertEquals(
+			array( 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+			$entry['schema']['properties']['categories']
+		);
+	}
+
+	public function test_spec30_formdata_multi_array_encoding() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'categories', 'in' => 'formData', 'required' => false, 'type' => 'array', 'items' => array( 'type' => 'integer' ), 'collectionFormat' => 'multi' ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$entry = $op['requestBody']['content']['application/x-www-form-urlencoded'];
+		$this->assertEquals(
+			array( 'style' => 'form', 'explode' => true ),
+			$entry['encoding']['categories']
+		);
+	}
+
+	public function test_spec30_formdata_scalar_no_encoding() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$entry = $op['requestBody']['content']['application/x-www-form-urlencoded'];
+		$this->assertArrayNotHasKey( 'encoding', $entry );
+	}
+
 	public function test_spec30_formdata_required_body() {
 		$spec = $this->specWithParams( array(
 			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -17,4 +17,32 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertInstanceOf( Spec20Formatter::class, SwaggerSpecRegistry::forVersion( '2.0' ) );
 		$this->assertInstanceOf( Spec20Formatter::class, SwaggerSpecRegistry::forVersion( 'bogus' ) );
 	}
+
+	public function test_registry_has_303() {
+		$this->assertContains( '3.0.3', SwaggerSpecRegistry::versions() );
+		$this->assertInstanceOf( Spec30Formatter::class, SwaggerSpecRegistry::forVersion( '3.0.3' ) );
+	}
+
+	public function test_spec30_top_level() {
+		$spec = array(
+			'swagger'  => '2.0',
+			'info'     => array( 'title' => 'T' ),
+			'host'     => 'example.com',
+			'basePath' => '/wp-json',
+			'tags'     => array(),
+			'schemes'  => array( 'https', 'http' ),
+			'paths'    => array(),
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$this->assertEquals( '3.0.3', $out['openapi'] );
+		$this->assertArrayNotHasKey( 'swagger', $out );
+		$this->assertArrayNotHasKey( 'host', $out );
+		$this->assertArrayNotHasKey( 'basePath', $out );
+		$this->assertArrayNotHasKey( 'schemes', $out );
+		$this->assertEquals( 'https://example.com/wp-json', $out['servers'][0]['url'] );
+		$this->assertEquals( 'http://example.com/wp-json', $out['servers'][1]['url'] );
+		$this->assertSame( array(), $out['tags'] );
+		$this->assertEquals( array( 'title' => 'T' ), $out['info'] );
+	}
 }

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -203,6 +203,15 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'collectionFormat', $param );
 	}
 
+	public function test_spec30_array_without_items_gets_default() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'status', 'in' => 'query', 'required' => false, 'type' => 'array' ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( array( 'type' => 'string' ), $param['schema']['items'] );
+	}
+
 	public function test_spec30_scalar_param_no_style() {
 		$spec  = $this->specWithParams( array(
 			array( 'name' => 'search', 'in' => 'query', 'required' => false, 'type' => 'string' ),
@@ -370,6 +379,34 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'schema', $op['responses']['200'] );
 		$this->assertEquals( array( 'type' => 'object' ), $op['responses']['200']['content']['application/json']['schema'] );
 		$this->assertEquals( 'OK', $op['responses']['200']['description'] );
+	}
+
+	public function test_spec30_response_examples_to_content() {
+		$spec = array(
+			'host'     => 'e.com',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array(
+				'/x' => array(
+					'get' => array(
+						'produces'  => array( 'application/json' ),
+						'responses' => array(
+							'200' => array(
+								'description' => 'OK',
+								'schema'      => array( 'type' => 'object' ),
+								'examples'    => array( 'application/json' => array( 'a' => 1 ) ),
+							),
+						),
+					),
+				),
+			),
+		);
+		$op = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertArrayNotHasKey( 'schema', $op['responses']['200'] );
+		$this->assertArrayNotHasKey( 'examples', $op['responses']['200'] );
+		$this->assertEquals( array( 'type' => 'object' ), $op['responses']['200']['content']['application/json']['schema'] );
+		$this->assertEquals( array( 'a' => 1 ), $op['responses']['200']['content']['application/json']['example'] );
 	}
 
 	public function test_spec30_description_only_response_unchanged() {

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -44,7 +44,6 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$out = ( new Spec30Formatter() )->format( $spec );
 
 		$this->assertEquals( '3.0.3', $out['openapi'] );
-		$this->assertArrayNotHasKey( 'swagger', $out );
 		$this->assertArrayNotHasKey( 'host', $out );
 		$this->assertArrayNotHasKey( 'basePath', $out );
 		$this->assertArrayNotHasKey( 'schemes', $out );
@@ -182,7 +181,7 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 
 	public function test_spec30_formdata_to_requestbody() {
 		$spec = $this->specWithParams( array(
-			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),
+			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'description' => 'Post title', 'type' => 'string' ),
 			array( 'name' => 'excerpt', 'in' => 'formData', 'required' => false, 'type' => 'string' ),
 		), 'post' );
 		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
@@ -190,7 +189,7 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'parameters', $op );
 		$schema = $op['requestBody']['content']['application/x-www-form-urlencoded']['schema'];
 		$this->assertEquals( 'object', $schema['type'] );
-		$this->assertEquals( array( 'type' => 'string' ), $schema['properties']['title'] );
+		$this->assertEquals( array( 'description' => 'Post title', 'type' => 'string' ), $schema['properties']['title'] );
 		$this->assertEquals( array( 'type' => 'string' ), $schema['properties']['excerpt'] );
 		$this->assertEquals( array( 'title' ), $schema['required'] );
 	}

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -683,4 +683,25 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 
 		unset( $_POST['_wpnonce'], $_POST['swagger_api_spec_version'] );
 	}
+
+	public function test_setting_save_expose_contact_email_checkbox() {
+		if ( ! class_exists( 'SwaggerSetting' ) ) {
+			require_once dirname( __DIR__ ) . '/swaggersetting.php';
+		}
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		$setting = new SwaggerSetting();
+
+		$_POST['_wpnonce']                         = wp_create_nonce( 'swagger_api_setting' );
+		$_POST['swagger_api_expose_contact_email'] = '1';
+		$setting->saveSetting();
+		$this->assertEquals( '1', get_option( 'swagger_api_expose_contact_email' ) );
+
+		unset( $_POST['swagger_api_expose_contact_email'] ); // unchecked = absent
+		$setting->saveSetting();
+		$this->assertEquals( '0', get_option( 'swagger_api_expose_contact_email' ), 'unchecked box must store 0' );
+
+		unset( $_POST['_wpnonce'] );
+	}
 }

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -3,9 +3,11 @@
 class TestSwaggerOpenApi extends WP_UnitTestCase {
 
 	public function test_spec20_passthrough() {
-		$spec = array( 'swagger' => '2.0', 'paths' => array( '/x' => array() ) );
+		$spec = array( 'paths' => array( '/x' => array() ) );
 		$f    = new Spec20Formatter();
-		$this->assertSame( $spec, $f->format( $spec ) );
+		$out  = $f->format( $spec );
+		$this->assertEquals( '2.0', $out['swagger'] );
+		$this->assertEquals( array( '/x' => array() ), $out['paths'] );
 		$this->assertEquals( '2.0', $f->version() );
 	}
 
@@ -23,9 +25,15 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertInstanceOf( Spec30Formatter::class, SwaggerSpecRegistry::forVersion( '3.0.3' ) );
 	}
 
+	public function test_spec30_openapi_is_first_key() {
+		$spec = array( 'info' => array( 'title' => 'T' ), 'paths' => array() );
+		$out  = ( new Spec30Formatter() )->format( $spec );
+
+		$this->assertEquals( 'openapi', array_key_first( $out ) );
+	}
+
 	public function test_spec30_top_level() {
 		$spec = array(
-			'swagger'  => '2.0',
 			'info'     => array( 'title' => 'T' ),
 			'host'     => 'example.com',
 			'basePath' => '/wp-json',
@@ -48,7 +56,6 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 
 	public function test_spec30_security_schemes() {
 		$spec = array(
-			'swagger'             => '2.0',
 			'host'                => 'e.com',
 			'basePath'            => '/wp-json',
 			'schemes'             => array( 'https' ),
@@ -80,14 +87,13 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 	}
 
 	public function test_spec30_no_security_definitions() {
-		$spec = array( 'swagger' => '2.0', 'host' => 'e.com', 'basePath' => '/wp-json', 'schemes' => array( 'https' ) );
+		$spec = array( 'host' => 'e.com', 'basePath' => '/wp-json', 'schemes' => array( 'https' ) );
 		$out  = ( new Spec30Formatter() )->format( $spec );
 		$this->assertArrayNotHasKey( 'components', $out );
 	}
 
 	private function specWithParams( array $params, string $method = 'get' ): array {
 		return array(
-			'swagger'  => '2.0',
 			'host'     => 'e.com',
 			'basePath' => '/wp-json',
 			'schemes'  => array( 'https' ),
@@ -153,6 +159,16 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 			array( 'type' => 'string', 'enum' => array( 'a', 'b' ), 'default' => 'a' ),
 			$param['schema']['items']
 		);
+	}
+
+	public function test_spec30_unknown_param_keyword_goes_to_schema() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'search', 'in' => 'query', 'required' => false, 'type' => 'string', 'pattern' => '^x' ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertArrayNotHasKey( 'pattern', $param );
+		$this->assertEquals( '^x', $param['schema']['pattern'] );
 	}
 
 	public function test_spec30_preexisting_schema_not_clobbered() {

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -159,4 +159,32 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 
 		$this->assertEquals( array( 'type' => 'integer', 'format' => 'int64' ), $param['schema'] );
 	}
+
+	public function test_spec30_formdata_to_requestbody() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),
+			array( 'name' => 'excerpt', 'in' => 'formData', 'required' => false, 'type' => 'string' ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertArrayNotHasKey( 'parameters', $op );
+		$schema = $op['requestBody']['content']['application/x-www-form-urlencoded']['schema'];
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertEquals( array( 'type' => 'string' ), $schema['properties']['title'] );
+		$this->assertEquals( array( 'type' => 'string' ), $schema['properties']['excerpt'] );
+		$this->assertEquals( array( 'title' ), $schema['required'] );
+	}
+
+	public function test_spec30_body_param_to_json_requestbody() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'schema' => array( 'type' => 'object' ) ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertArrayNotHasKey( 'parameters', $op );
+		$this->assertEquals(
+			array( 'type' => 'object' ),
+			$op['requestBody']['content']['application/json']['schema']
+		);
+	}
 }

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -91,6 +91,18 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'components', $out );
 	}
 
+	public function test_spec30_non_array_security_definitions_no_crash() {
+		$spec = array(
+			'host'                => 'e.com',
+			'basePath'            => '/wp-json',
+			'schemes'             => array( 'https' ),
+			'securityDefinitions' => 'x',
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$this->assertArrayNotHasKey( 'components', $out );
+	}
+
 	private function specWithParams( array $params, string $method = 'get', array $consumes = array( 'application/x-www-form-urlencoded' ) ): array {
 		return array(
 			'host'     => 'e.com',
@@ -123,6 +135,25 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'consumes', $op );
 		$this->assertArrayNotHasKey( 'produces', $op );
 		$this->assertEquals( array( '200' => array( 'description' => 'OK' ) ), $op['responses'] );
+	}
+
+	public function test_spec30_non_array_responses_no_crash() {
+		$spec = array(
+			'host'     => 'e.com',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array(
+				'/x' => array(
+					'get' => array(
+						'tags'      => array( 'x' ),
+						'responses' => 'foo',
+					),
+				),
+			),
+		);
+		$op = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( 'foo', $op['responses'] );
 	}
 
 	public function test_spec30_scalar_param_to_schema() {
@@ -214,6 +245,18 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertEquals( array( 'description' => 'Post title', 'type' => 'string' ), $schema['properties']['title'] );
 		$this->assertEquals( array( 'type' => 'string' ), $schema['properties']['excerpt'] );
 		$this->assertEquals( array( 'title' ), $schema['required'] );
+	}
+
+	public function test_spec30_formdata_nameless_param_skipped() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'title', 'in' => 'formData', 'required' => false, 'type' => 'string' ),
+			array( 'in' => 'formData', 'required' => false, 'type' => 'string' ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$properties = $op['requestBody']['content']['application/x-www-form-urlencoded']['schema']['properties'];
+		$this->assertEquals( array( 'title' ), array_keys( $properties ) );
+		$this->assertArrayNotHasKey( '', $properties );
 	}
 
 	public function test_spec30_formdata_drops_collectionformat() {
@@ -522,6 +565,47 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 			),
 			$out['components']['securitySchemes']['oauth']
 		);
+	}
+
+	public function test_spec30_oauth2_empty_scopes_is_object() {
+		$spec = array(
+			'host'                => 'e.com',
+			'basePath'            => '/wp-json',
+			'schemes'             => array( 'https' ),
+			'securityDefinitions' => array(
+				'oauth' => array(
+					'type'             => 'oauth2',
+					'flow'             => 'implicit',
+					'authorizationUrl' => 'https://ex/auth',
+				),
+			),
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$scopes = $out['components']['securitySchemes']['oauth']['flows']['implicit']['scopes'];
+		$this->assertInstanceOf( \stdClass::class, $scopes );
+		$this->assertStringContainsString( '"scopes":{}', wp_json_encode( $out['components']['securitySchemes']['oauth'] ) );
+	}
+
+	public function test_spec30_bearer_keyed_oauth2_converts() {
+		$spec = array(
+			'host'                => 'e.com',
+			'basePath'            => '/wp-json',
+			'schemes'             => array( 'https' ),
+			'securityDefinitions' => array(
+				'bearer' => array(
+					'type'             => 'oauth2',
+					'flow'             => 'implicit',
+					'authorizationUrl' => 'https://x/a',
+				),
+			),
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$scheme = $out['components']['securitySchemes']['bearer'];
+		$this->assertEquals( 'oauth2', $scheme['type'] );
+		$this->assertEquals( 'https://x/a', $scheme['flows']['implicit']['authorizationUrl'] );
+		$this->assertInstanceOf( \stdClass::class, $scheme['flows']['implicit']['scopes'] );
 	}
 
 	public function test_spec30_unknown_apikey_scheme_passthrough() {

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -382,6 +382,83 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_spec30_path_array_param_simple_style() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'ids', 'in' => 'path', 'required' => true, 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( 'simple', $param['style'] );
+		$this->assertFalse( $param['explode'] );
+
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'ids', 'in' => 'header', 'required' => true, 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( 'simple', $param['style'] );
+		$this->assertFalse( $param['explode'] );
+	}
+
+	public function test_spec30_query_array_still_form() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'author', 'in' => 'query', 'required' => false, 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( 'form', $param['style'] );
+		$this->assertFalse( $param['explode'] );
+	}
+
+	public function test_spec30_oauth2_scheme_converted() {
+		$spec = array(
+			'host'                => 'e.com',
+			'basePath'            => '/wp-json',
+			'schemes'             => array( 'https' ),
+			'securityDefinitions' => array(
+				'oauth' => array(
+					'type'             => 'oauth2',
+					'flow'             => 'accessCode',
+					'authorizationUrl' => 'https://ex/auth',
+					'tokenUrl'         => 'https://ex/token',
+					'scopes'           => array( 'read' => 'Read' ),
+				),
+			),
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$this->assertEquals(
+			array(
+				'type'  => 'oauth2',
+				'flows' => array(
+					'authorizationCode' => array(
+						'authorizationUrl' => 'https://ex/auth',
+						'tokenUrl'         => 'https://ex/token',
+						'scopes'           => array( 'read' => 'Read' ),
+					),
+				),
+			),
+			$out['components']['securitySchemes']['oauth']
+		);
+	}
+
+	public function test_spec30_unknown_apikey_scheme_passthrough() {
+		$spec = array(
+			'host'                => 'e.com',
+			'basePath'            => '/wp-json',
+			'schemes'             => array( 'https' ),
+			'securityDefinitions' => array(
+				'x' => array( 'type' => 'apiKey', 'in' => 'header', 'name' => 'X-Key' ),
+			),
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$this->assertEquals(
+			array( 'type' => 'apiKey', 'in' => 'header', 'name' => 'X-Key' ),
+			$out['components']['securitySchemes']['x']
+		);
+	}
+
 	public function test_setting_save_whitelists_version() {
 		if ( ! class_exists( 'SwaggerSetting' ) ) {
 			require_once dirname( __DIR__ ) . '/swaggersetting.php';

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -221,6 +221,69 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_spec30_response_schema_to_content() {
+		$spec = array(
+			'host'     => 'e.com',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array(
+				'/x' => array(
+					'get' => array(
+						'produces'  => array( 'application/json' ),
+						'responses' => array(
+							'200' => array( 'description' => 'OK', 'schema' => array( 'type' => 'object' ) ),
+						),
+					),
+				),
+			),
+		);
+		$op = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertArrayNotHasKey( 'schema', $op['responses']['200'] );
+		$this->assertEquals( array( 'type' => 'object' ), $op['responses']['200']['content']['application/json']['schema'] );
+		$this->assertEquals( 'OK', $op['responses']['200']['description'] );
+	}
+
+	public function test_spec30_description_only_response_unchanged() {
+		$spec = array(
+			'host'     => 'e.com',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array(
+				'/x' => array(
+					'get' => array(
+						'responses' => array( '200' => array( 'description' => 'OK' ) ),
+					),
+				),
+			),
+		);
+		$op = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( array( '200' => array( 'description' => 'OK' ) ), $op['responses'] );
+	}
+
+	public function test_spec30_body_required_on_requestbody() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'schema' => array( 'type' => 'object' ) ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertTrue( $op['requestBody']['required'] );
+		$this->assertEquals(
+			array( 'type' => 'object' ),
+			$op['requestBody']['content']['application/json']['schema']
+		);
+	}
+
+	public function test_spec30_body_not_required_omits_requestbody_required() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'payload', 'in' => 'body', 'required' => false, 'schema' => array( 'type' => 'object' ) ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertArrayNotHasKey( 'required', $op['requestBody'] );
+	}
+
 	public function test_setting_save_whitelists_version() {
 		if ( ! class_exists( 'SwaggerSetting' ) ) {
 			require_once dirname( __DIR__ ) . '/swaggersetting.php';

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -160,6 +160,28 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_spec30_csv_array_param_explode_false() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'author', 'in' => 'query', 'required' => false, 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertEquals( 'form', $param['style'] );
+		$this->assertFalse( $param['explode'] );
+		$this->assertEquals( 'array', $param['schema']['type'] );
+		$this->assertArrayNotHasKey( 'collectionFormat', $param );
+	}
+
+	public function test_spec30_scalar_param_no_style() {
+		$spec  = $this->specWithParams( array(
+			array( 'name' => 'search', 'in' => 'query', 'required' => false, 'type' => 'string' ),
+		) );
+		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
+
+		$this->assertArrayNotHasKey( 'style', $param );
+		$this->assertArrayNotHasKey( 'explode', $param );
+	}
+
 	public function test_spec30_unknown_param_keyword_goes_to_schema() {
 		$spec  = $this->specWithParams( array(
 			array( 'name' => 'search', 'in' => 'query', 'required' => false, 'type' => 'string', 'pattern' => '^x' ),
@@ -206,6 +228,29 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 			$property
 		);
 		$this->assertArrayNotHasKey( 'collectionFormat', $property );
+	}
+
+	public function test_spec30_formdata_required_body() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),
+			array( 'name' => 'excerpt', 'in' => 'formData', 'required' => false, 'type' => 'string' ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertTrue( $op['requestBody']['required'] );
+		$this->assertEquals(
+			array( 'title' ),
+			$op['requestBody']['content']['application/x-www-form-urlencoded']['schema']['required']
+		);
+	}
+
+	public function test_spec30_formdata_optional_body_no_required() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'excerpt', 'in' => 'formData', 'required' => false, 'type' => 'string' ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertArrayNotHasKey( 'required', $op['requestBody'] );
 	}
 
 	public function test_spec30_body_param_to_json_requestbody() {

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -369,6 +369,28 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'required', $op['requestBody'] );
 	}
 
+	public function test_spec30_body_description_carried() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'description' => 'Created user object', 'schema' => array( 'type' => 'object' ) ),
+		), 'post', array( 'application/json' ) );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertEquals( 'Created user object', $op['requestBody']['description'] );
+		$this->assertEquals(
+			array( 'type' => 'object' ),
+			$op['requestBody']['content']['application/json']['schema']
+		);
+	}
+
+	public function test_spec30_body_no_description_omitted() {
+		$spec = $this->specWithParams( array(
+			array( 'name' => 'payload', 'in' => 'body', 'required' => true, 'schema' => array( 'type' => 'object' ) ),
+		), 'post' );
+		$op   = $this->firstOperation( ( new Spec30Formatter() )->format( $spec ), 'post' );
+
+		$this->assertArrayNotHasKey( 'description', $op['requestBody'] );
+	}
+
 	public function test_spec30_formdata_consumes_override() {
 		$spec = $this->specWithParams( array(
 			array( 'name' => 'title', 'in' => 'formData', 'required' => true, 'type' => 'string' ),

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -70,7 +70,11 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 			$out['components']['securitySchemes']['basic']
 		);
 		$this->assertEquals(
-			array( 'type' => 'http', 'scheme' => 'bearer', 'description' => 'x' ),
+			array(
+				'type'        => 'http',
+				'scheme'      => 'bearer',
+				'description' => 'Enter your token; the "Bearer" prefix is added automatically.',
+			),
 			$out['components']['securitySchemes']['bearer']
 		);
 	}
@@ -153,7 +157,7 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 
 	public function test_spec30_preexisting_schema_not_clobbered() {
 		$spec  = $this->specWithParams( array(
-			array( 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => 'integer', 'schema' => array( 'type' => 'integer', 'format' => 'int64' ) ),
+			array( 'name' => 'id', 'in' => 'path', 'required' => true, 'type' => 'string', 'schema' => array( 'type' => 'integer', 'format' => 'int64' ) ),
 		) );
 		$param = $this->firstParam( ( new Spec30Formatter() )->format( $spec ) );
 

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -141,4 +141,20 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$this->assertEquals( [ 'pets' ], $methods['get']['tags'] );
 	}
 
+	public function test_getMethodsFromArgs_consumes_are_flat_strings() {
+		$args = [
+			[
+				'methods'      => [ 'POST' => true ],
+				'accept_json'  => true,
+			],
+		];
+		$methods = $this->ui->getMethodsFromArgs( '/pets', '/wp/v2/pets', $args );
+		$consumes = $methods['post']['consumes'];
+
+		foreach ( $consumes as $item ) {
+			$this->assertTrue( is_string( $item ) );
+		}
+		$this->assertTrue( in_array( 'application/json', $consumes, true ) );
+	}
+
 }

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -65,7 +65,8 @@ class WP_API_SwaggerUI
 
         global $wp_version;
 
-        $contact_email = apply_filters('swagger_api_contact_email', get_option('admin_email'));
+        $expose_email  = '1' === get_option('swagger_api_expose_contact_email', '1');
+        $contact_email = apply_filters('swagger_api_contact_email', $expose_email ? get_option('admin_email') : '');
 
         $info = array(
             'title' => get_option('blogname') . ' API',

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -25,6 +25,7 @@ if (version_compare(PHP_VERSION, '7.4', '<') || version_compare($wp_version, '4.
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'swaggerbag.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'swaggerauth.php';
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'swaggertemplate.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'swaggeropenapi.php';
 
 if (is_admin()) {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'swaggersetting.php';

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -87,7 +87,7 @@ class WP_API_SwaggerUI
         // the key (rather than emitting an empty map) keeps /schema valid Swagger
         // 2.0 and stops Swagger UI rendering a stray, empty Authorize dialog.
         $securityDefinitions = $this->securityDefinitions();
-        if (!empty($securityDefinitions)) {
+        if (is_array($securityDefinitions) && !empty($securityDefinitions)) {
             $response['securityDefinitions'] = $securityDefinitions;
         }
 

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -65,8 +65,9 @@ class WP_API_SwaggerUI
 
         global $wp_version;
 
+        // Canonical Swagger 2.0 pivot document. Each formatter stamps its own
+        // version marker (swagger/openapi) and reshapes from here.
         $response = array(
-            'swagger' => '2.0',
             'info' => array(
                 'title' => get_option('blogname') . ' API',
                 'description' => get_option('blogdescription'),

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -90,7 +90,8 @@ class WP_API_SwaggerUI
             $response['securityDefinitions'] = $securityDefinitions;
         }
 
-        wp_send_json($response);
+        $formatter = SwaggerSpecRegistry::forVersion(get_option('swagger_api_spec_version', '2.0'));
+        wp_send_json($formatter->format($response));
     }
 
     public function getHost()

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: WP API SwaggerUI
  * Description: WordPress REST API with Swagger UI.
- * Version:     2.1.1
+ * Version:     2.2.0
  * Author:      Agus Suroyo
  * Requires PHP: 7.4
  * License:     GPL v2 or later

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -65,17 +65,21 @@ class WP_API_SwaggerUI
 
         global $wp_version;
 
+        $contact_email = apply_filters('swagger_api_contact_email', get_option('admin_email'));
+
+        $info = array(
+            'title' => get_option('blogname') . ' API',
+            'description' => get_option('blogdescription'),
+            'version' => apply_filters('swagger_api_info_version', $wp_version),
+        );
+        if (!empty($contact_email)) {
+            $info['contact'] = array('email' => $contact_email);
+        }
+
         // Canonical Swagger 2.0 pivot document. Each formatter stamps its own
         // version marker (swagger/openapi) and reshapes from here.
         $response = array(
-            'info' => array(
-                'title' => get_option('blogname') . ' API',
-                'description' => get_option('blogdescription'),
-                'version' => $wp_version,
-                'contact' => array(
-                    'email' => get_option('admin_email')
-                )
-            ),
+            'info' => $info,
             'host' => $this->getHost(),
             'basePath' => $this->getBasePath(),
             'tags' => [],
@@ -92,7 +96,11 @@ class WP_API_SwaggerUI
         }
 
         $formatter = SwaggerSpecRegistry::forVersion(get_option('swagger_api_spec_version', '2.0'));
-        wp_send_json($formatter->format($response));
+        $output    = $formatter->format($response);
+        if (empty($output['paths'])) {
+            $output['paths'] = new \stdClass();
+        }
+        wp_send_json($output);
     }
 
     public function getHost()

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -241,7 +241,7 @@ class WP_API_SwaggerUI
                 }
 
                 if ($arg['accept_json']) {
-                    $consumes[] = ['application/json'];
+                    $consumes[] = 'application/json';
                 }
 
                 $responses =$this->getResponses($methodEndpoint);


### PR DESCRIPTION
Resolves #7 — adds OpenAPI 3.0.3 output to the `/schema` endpoint, selectable from an admin dropdown, alongside the existing Swagger 2.0. Default stays **2.0**, so existing installs are unaffected; 3.0.3 is opt-in.

## Approach

The existing `swagger()` build remains the single source of truth (a canonical Swagger 2.0 pivot document). At output time a `SwaggerSpecFormatter` chosen by `SwaggerSpecRegistry::forVersion(get_option('swagger_api_spec_version', '2.0'))` renders the final spec:

- `Spec20Formatter` — stamps the `swagger` marker (passthrough).
- `Spec30Formatter` — transforms 2.0 → 3.0.3: `host`/`basePath`/`schemes` → `servers`; parameter `type`/`format`/`items`/`min`/`max` → nested `schema{}`; `collectionFormat: multi` → `style`/`explode`; `formData`/`body` params → `requestBody`; `securityDefinitions` → `components.securitySchemes`; drops `consumes`/`produces`.

No JavaScript change: `swagger-ui-dist` auto-detects `swagger` vs `openapi` from the document.

The version marker lives in each formatter (via `version()`), not the builder, so version identity is single-sourced and a document can never carry both `swagger` and `openapi`. Parameter keys are relocated into `schema{}` by exclusion, so future 2.0 keywords can't leak onto a 3.0 Parameter Object.

## Setting

New option `swagger_api_spec_version` with an "OpenAPI Version" dropdown on Settings → Swagger. The save path reuses the existing nonce + `manage_options` guard and validates the posted value against `SwaggerSpecRegistry::versions()` (strict whitelist); unknown values fall back to safe 2.0.

## Tests

New `tests/test-swaggeropenapi.php` covers the formatter contract, registry fallback, top-level transform, security schemes (present/absent), parameter → schema (including the enum/array + `collectionFormat` path and pre-existing-`schema` no-clobber), `formData` → `requestBody` (with property descriptions), and the admin whitelist. Full suite: **58 tests green**.

## Also included

- Fix (pre-existing): `$consumes[] = ['application/json']` pushed a nested array, producing malformed `consumes` in 2.0 output — now pushes a string.

## Base

Branched from `feat/tags-support` (unmerged), so this PR targets that branch for a clean OpenAPI-only diff.