### PR TITLE
fix: preserve nested object/array schemas and emit valid Swagger 2 params

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ SwaggerUI used to make WordPress REST API endpoint have a interactive UI, so we 
 - Support for `GET`, `POST`, `PUT`, `PATCH` and `DELETE` request methods
 - Support for Auth Basic authorization method
 - Support for Bearer token (`Authorization` header) authorization method
+- Choose which authorization methods (Basic / Bearer) appear in the Swagger UI Authorize dialog
+- Output as Swagger 2.0 (default) or OpenAPI 3.0.3
+- Option to include or omit the site admin contact email in the generated schema
 - Choose which namespace API that will be used on the SwaggerUI
 
 ![alt text](https://i.ibb.co/p0Kjhpn/Screen-Shot-2019-07-25-at-08-57-32.png)
   
 ## Requirements
  - Your website should not block support of WordPress default REST API
- - Works for WordPress REST API Version 2
- - PHP Version should be greater than 5.4 
+ - WordPress 4.7 or later (REST API v2)
+ - PHP 7.4 or later
 
 ## Installation
 ### Manual Installation
@@ -46,6 +49,12 @@ From the Swagger Setting page, choose between the API Basepath options displayed
 ### Access Swagger UI
 You can see Swagger Docs URL accessing:
   - http://example.com/rest-api/docs/
+
+### Settings
+The Swagger Setting page (Settings → Swagger) also offers:
+  - **Authentication** — pick which methods (Basic / Bearer) appear in the Swagger UI Authorize dialog. Bearer requires a token plugin (e.g. JWT) to validate requests.
+  - **OpenAPI Version** — output as Swagger 2.0 (default) or OpenAPI 3.0.3.
+  - **Contact Email** — include or omit the site admin email as the API contact. Override via the `swagger_api_contact_email` filter.
 
 ### Authorization
 On WordPress 5.6+, the Swagger UI **Authorize** (Basic) prompt is handled by WordPress'
@@ -179,6 +188,8 @@ register_rest_route(
 )
 ```
 > These examples were based on the defaults presented at [Swagger Editor](https://editor.swagger.io)
+
+> **Note:** For `POST`/`PUT`/`PATCH` routes, registered JSON `args` are automatically combined into a single request body — you don't need to define an explicit `body` arg. Nested object/array schemas (with `enum`, `required`, `format`, `default`) are preserved. File uploads stay on `multipart/form-data`.
 
 ## Guide
 

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,10 @@ Feature:
 
 * Support for GET, POST, PUT, PATCH and DELETE request method
 * Support for Auth Basic authorization method
+* Support for Bearer token (Authorization header) authorization method
+* Choose which authorization methods (Basic / Bearer) appear in the Swagger UI Authorize dialog
+* Output as Swagger 2.0 (default) or OpenAPI 3.0.3
+* Option to include or omit the site admin contact email in the generated schema
 * Choose which namespace API that will be used on the SwaggerUI
 
 == Installation ==

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/agussuroyo
 Tags: swaggerui, wp swaggerui, wp rest api, wp swagger rest api, swaggerui rest api, swagger rest api, wp swagger, api, swagger, rest api
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 2.2.0
+Stable tag: 2.3.0
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -36,6 +36,12 @@ This plugin can be installed directly from your site.
 2. Options to choose namespace Rest API
 
 == Changelog ==
+
+= 2.3.0 =
+* Fix nested object and array item properties not showing in Swagger UI (recursive schema normalization)
+* Combine registered JSON arguments into a single request body for POST/PUT/PATCH routes
+* Preserve enum, required, format and default across nested schemas; keep file uploads on multipart/form-data
+* Improve OpenAPI 3.0.3 output: move definitions to components.schemas and rewrite $ref targets
 
 = 2.2.0 =
 * Add OpenAPI 3.0.3 output, selectable in Settings → Swagger (default stays Swagger 2.0, so existing installs are unchanged)

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -30,16 +30,36 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		if ( isset( $spec['securityDefinitions'] ) && is_array( $spec['securityDefinitions'] ) ) {
 			$schemes = $this->mapSecuritySchemes( $spec['securityDefinitions'] );
 			if ( ! empty( $schemes ) ) {
-				$spec['components'] = array( 'securitySchemes' => $schemes );
+				$spec['components']['securitySchemes'] = $schemes;
 			}
 			unset( $spec['securityDefinitions'] );
+		}
+
+		if ( isset( $spec['definitions'] ) && is_array( $spec['definitions'] ) ) {
+			$existing_schemas               = isset( $spec['components']['schemas'] ) && is_array( $spec['components']['schemas'] ) ? $spec['components']['schemas'] : array();
+			$spec['components']['schemas'] = $existing_schemas + $spec['definitions'];
+			unset( $spec['definitions'] );
 		}
 
 		if ( isset( $spec['paths'] ) ) {
 			$spec['paths'] = $this->mapPaths( $spec['paths'] );
 		}
 
+		$spec = $this->rewriteRefs( $spec );
+
 		return $spec;
+	}
+
+	private function rewriteRefs(array $data): array {
+		$prefix = '#/definitions/';
+		foreach ( $data as $key => $value ) {
+			if ( '$ref' === $key && is_string( $value ) && 0 === strpos( $value, $prefix ) ) {
+				$data[ $key ] = '#/components/schemas/' . substr( $value, strlen( $prefix ) );
+			} elseif ( is_array( $value ) ) {
+				$data[ $key ] = $this->rewriteRefs( $value );
+			}
+		}
+		return $data;
 	}
 
 	private function mapPaths(array $paths): array {
@@ -268,6 +288,31 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			$schema['type']   = 'string';
 			$schema['format'] = 'binary';
 		}
+
+		foreach ( array( 'items', 'schema', 'additionalProperties' ) as $key ) {
+			if ( isset( $schema[ $key ] ) && is_array( $schema[ $key ] ) ) {
+				$schema[ $key ] = $this->normalizeFileSchema( $schema[ $key ] );
+			}
+		}
+
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $name => $property ) {
+				if ( is_array( $property ) ) {
+					$schema['properties'][ $name ] = $this->normalizeFileSchema( $property );
+				}
+			}
+		}
+
+		foreach ( array( 'allOf', 'oneOf', 'anyOf' ) as $combinator ) {
+			if ( isset( $schema[ $combinator ] ) && is_array( $schema[ $combinator ] ) ) {
+				foreach ( $schema[ $combinator ] as $index => $branch ) {
+					if ( is_array( $branch ) ) {
+						$schema[ $combinator ][ $index ] = $this->normalizeFileSchema( $branch );
+					}
+				}
+			}
+		}
+
 		return $schema;
 	}
 

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -53,6 +53,10 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	private function rewriteRefs(array $data): array {
 		$prefix = '#/definitions/';
 		foreach ( $data as $key => $value ) {
+			// Do not touch literal payload data; only schema-bearing locations carry real $refs.
+			if ( 'example' === $key || 'examples' === $key ) {
+				continue;
+			}
 			if ( '$ref' === $key && is_string( $value ) && 0 === strpos( $value, $prefix ) ) {
 				$data[ $key ] = '#/components/schemas/' . substr( $value, strlen( $prefix ) );
 			} elseif ( is_array( $value ) ) {

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -36,34 +36,55 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		}
 
 		if ( isset( $spec['definitions'] ) && is_array( $spec['definitions'] ) ) {
-			$existing_schemas               = isset( $spec['components']['schemas'] ) && is_array( $spec['components']['schemas'] ) ? $spec['components']['schemas'] : array();
+			$existing_schemas              = isset( $spec['components']['schemas'] ) && is_array( $spec['components']['schemas'] ) ? $spec['components']['schemas'] : array();
 			$spec['components']['schemas'] = $existing_schemas + $spec['definitions'];
 			unset( $spec['definitions'] );
+		}
+
+		if ( isset( $spec['components']['schemas'] ) && is_array( $spec['components']['schemas'] ) ) {
+			foreach ( $spec['components']['schemas'] as $name => $schema ) {
+				$spec['components']['schemas'][ $name ] = $this->rewriteSchemaRefs( $schema );
+			}
 		}
 
 		if ( isset( $spec['paths'] ) ) {
 			$spec['paths'] = $this->mapPaths( $spec['paths'] );
 		}
 
-		$spec = $this->rewriteRefs( $spec );
-
 		return $spec;
 	}
 
-	private function rewriteRefs(array $data): array {
+	/**
+	 * Rewrite JSON Reference targets from Swagger 2 (#/definitions/) to OpenAPI 3
+	 * (#/components/schemas/). Descends only through schema keywords, so a "$ref"
+	 * key sitting in literal example/default data is never rewritten.
+	 */
+	private function rewriteSchemaRefs($schema) {
+		if ( ! is_array( $schema ) ) {
+			return $schema;
+		}
 		$prefix = '#/definitions/';
-		foreach ( $data as $key => $value ) {
-			// Do not touch literal payload data; only schema-bearing locations carry real $refs.
-			if ( 'example' === $key || 'examples' === $key ) {
-				continue;
-			}
-			if ( '$ref' === $key && is_string( $value ) && 0 === strpos( $value, $prefix ) ) {
-				$data[ $key ] = '#/components/schemas/' . substr( $value, strlen( $prefix ) );
-			} elseif ( is_array( $value ) ) {
-				$data[ $key ] = $this->rewriteRefs( $value );
+		if ( isset( $schema['$ref'] ) && is_string( $schema['$ref'] ) && 0 === strpos( $schema['$ref'], $prefix ) ) {
+			$schema['$ref'] = '#/components/schemas/' . substr( $schema['$ref'], strlen( $prefix ) );
+		}
+		foreach ( array( 'items', 'additionalProperties' ) as $key ) {
+			if ( isset( $schema[ $key ] ) && is_array( $schema[ $key ] ) ) {
+				$schema[ $key ] = $this->rewriteSchemaRefs( $schema[ $key ] );
 			}
 		}
-		return $data;
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $name => $sub ) {
+				$schema['properties'][ $name ] = $this->rewriteSchemaRefs( $sub );
+			}
+		}
+		foreach ( array( 'allOf', 'oneOf', 'anyOf' ) as $key ) {
+			if ( isset( $schema[ $key ] ) && is_array( $schema[ $key ] ) ) {
+				foreach ( $schema[ $key ] as $i => $branch ) {
+					$schema[ $key ][ $i ] = $this->rewriteSchemaRefs( $branch );
+				}
+			}
+		}
+		return $schema;
 	}
 
 	private function mapPaths(array $paths): array {
@@ -150,7 +171,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 			foreach ( $produces as $m ) {
 				$entry = array();
 				if ( null !== $schema ) {
-					$entry['schema'] = $schema;
+					$entry['schema'] = $this->rewriteSchemaRefs( $schema );
 				}
 				if ( isset( $examples[ $m ] ) ) {
 					$entry['example'] = $examples[ $m ];
@@ -181,7 +202,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 		}
 
 		if ( ! empty( $schema ) ) {
-			$param['schema'] = $schema;
+			$param['schema'] = $this->rewriteSchemaRefs( $schema );
 		}
 
 		if ( isset( $schema['type'] ) && 'array' === $schema['type'] ) {
@@ -230,6 +251,7 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	}
 
 	private function contentFor(array $media, array $schema): array {
+		$schema  = $this->rewriteSchemaRefs( $schema );
 		$content = array();
 		foreach ( $media as $m ) {
 			$content[ $m ] = array( 'schema' => $schema );

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -682,21 +682,46 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'type', $prop );
 	}
 
-	public function test_file_plus_explicit_body_keeps_body_schema() {
+	public function test_file_plus_explicit_body_flattens_into_multipart() {
 		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
 			'methods'     => array( 'POST' => true ),
 			'accept_json' => true,
 			'args'        => array(
 				'file' => array( 'type' => 'file' ),
-				'meta' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ) ) ),
+				'meta' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ), 'required' => array( 'x' ) ) ),
 			),
 		)) )['post'];
 
-		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
-			return isset( $p['in'] ) && 'body' === $p['in'];
-		} ) );
-		$this->assertCount( 1, $bodies );
-		$this->assertArrayHasKey( 'x', $bodies[0]['schema']['properties'] );
+		$ins = array_map( function ( $p ) { return $p['in']; }, $operation['parameters'] );
+		$this->assertNotContains( 'body', $ins );
+		$this->assertEquals( array( 'multipart/form-data' ), $operation['consumes'] );
+
+		$by_name = array();
+		foreach ( $operation['parameters'] as $p ) {
+			$by_name[ $p['name'] ] = $p;
+		}
+		$this->assertArrayHasKey( 'file', $by_name );
+		$this->assertArrayHasKey( 'x', $by_name );
+		$this->assertEquals( 'formData', $by_name['x']['in'] );
+		$this->assertTrue( $by_name['x']['required'] );
+	}
+
+	public function test_openapi3_does_not_rewrite_refs_in_examples() {
+		$openapi = ( new Spec30Formatter() )->format(array(
+			'host'     => 'example.org',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array( '/sample' => array( 'get' => array(
+				'produces'  => array( 'application/json' ),
+				'responses' => array( '200' => array(
+					'description' => 'OK',
+					'examples'    => array( 'application/json' => array( '$ref' => '#/definitions/Thing' ) ),
+				) ),
+			) ) ),
+		));
+
+		$example = $openapi['paths']['/sample']['get']['responses']['200']['content']['application/json']['example'];
+		$this->assertEquals( '#/definitions/Thing', $example['$ref'] );
 	}
 
 	public function test_buildParameters() {

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -706,7 +706,7 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$this->assertTrue( $by_name['x']['required'] );
 	}
 
-	public function test_openapi3_does_not_rewrite_refs_in_examples() {
+	public function test_openapi3_rewrites_schema_refs_but_not_example_refs() {
 		$openapi = ( new Spec30Formatter() )->format(array(
 			'host'     => 'example.org',
 			'basePath' => '/wp-json',
@@ -715,13 +715,50 @@ class TestSwaggerUI extends WP_UnitTestCase {
 				'produces'  => array( 'application/json' ),
 				'responses' => array( '200' => array(
 					'description' => 'OK',
+					'schema'      => array( '$ref' => '#/definitions/Thing' ),
 					'examples'    => array( 'application/json' => array( '$ref' => '#/definitions/Thing' ) ),
 				) ),
 			) ) ),
 		));
 
-		$example = $openapi['paths']['/sample']['get']['responses']['200']['content']['application/json']['example'];
-		$this->assertEquals( '#/definitions/Thing', $example['$ref'] );
+		$entry = $openapi['paths']['/sample']['get']['responses']['200']['content']['application/json'];
+		// $ref in a schema position is rewritten for OpenAPI 3...
+		$this->assertEquals( '#/components/schemas/Thing', $entry['schema']['$ref'] );
+		// ...but an identical $ref sitting in literal example data is left alone.
+		$this->assertEquals( '#/definitions/Thing', $entry['example']['$ref'] );
+	}
+
+	public function test_non_body_param_drops_schema_only_keys() {
+		$params = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'GET' => true ),
+			'accept_json' => false,
+			'args'        => array( 'q' => array( 'type' => 'string', 'title' => 'Q', 'example' => 'hi', 'xml' => array( 'name' => 'Q' ), 'description' => 'search' ) ),
+		)) )['get']['parameters'];
+
+		$this->assertArrayNotHasKey( 'title', $params[0] );
+		$this->assertArrayNotHasKey( 'example', $params[0] );
+		$this->assertArrayNotHasKey( 'xml', $params[0] );
+		$this->assertEquals( 'search', $params[0]['description'] );
+		$this->assertEquals( 'string', $params[0]['type'] );
+	}
+
+	public function test_body_schema_preserves_xml_metadata() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => false,
+			'consumes'    => array( 'application/xml' ),
+			'args'        => array( 'payload' => array( 'in' => 'body', 'schema' => array(
+				'type'       => 'object',
+				'xml'        => array( 'name' => 'Payload' ),
+				'properties' => array( 'x' => array( 'type' => 'string', 'xml' => array( 'attribute' => true ) ) ),
+			) ) ),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$this->assertEquals( array( 'name' => 'Payload' ), $bodies[0]['schema']['xml'] );
+		$this->assertEquals( array( 'attribute' => true ), $bodies[0]['schema']['properties']['x']['xml'] );
 	}
 
 	public function test_buildParameters() {

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -93,6 +93,565 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'type', $params );
 	}
 
+	public function test_buildParams_preserves_nested_array_object_schema() {
+		$params = $this->ui->buildParams( 'data', 'post', '/sample', array(
+			'type'  => 'array',
+			'items' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'action' => array( 'type' => 'enum', 'enum' => array( 'add', 'update' ), 'required' => true ),
+					'dates'  => array( 'type' => 'array', 'items' => array( 'type' => 'string', 'format' => 'date-time' ) ),
+				),
+			),
+		) );
+
+		$this->assertEquals( 'object', $params['items']['type'] );
+		$this->assertEquals( 'string', $params['items']['properties']['action']['type'] );
+		$this->assertEquals( array( 'add', 'update' ), $params['items']['properties']['action']['enum'] );
+		$this->assertEquals( array( 'action' ), $params['items']['required'] );
+		$this->assertEquals( 'date-time', $params['items']['properties']['dates']['items']['format'] );
+		$this->assertArrayNotHasKey( 'required', $params['items']['properties']['action'] );
+	}
+
+	public function test_json_route_combines_registered_arguments_into_body_schema() {
+		$args = array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array(
+				'title' => array( 'type' => 'string', 'required' => true ),
+				'data'  => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'action'             => array( 'type' => 'string', 'enum' => array( 'add', 'update' ) ),
+							'date_created'       => array( 'type' => 'string' ),
+							'date_last_modified' => array( 'type' => 'string' ),
+						),
+					),
+				),
+			),
+		));
+
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', $args )['post'];
+		$this->assertCount( 1, $operation['parameters'] );
+		$this->assertEquals( 'body', $operation['parameters'][0]['in'] );
+		$this->assertEquals( array( 'title' ), $operation['parameters'][0]['schema']['required'] );
+		$this->assertArrayHasKey( 'action', $operation['parameters'][0]['schema']['properties']['data']['items']['properties'] );
+
+		$openapi = ( new Spec30Formatter() )->format(array(
+			'host'     => 'example.org',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array( '/sample' => array( 'post' => $operation ) ),
+		));
+		$request_schema = $openapi['paths']['/sample']['post']['requestBody']['content']['application/json']['schema'];
+		$this->assertArrayHasKey( 'date_created', $request_schema['properties']['data']['items']['properties'] );
+		$this->assertArrayHasKey( 'date_last_modified', $request_schema['properties']['data']['items']['properties'] );
+	}
+
+	public function test_non_json_scalar_parameters_remain_form_data() {
+		$params = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => false,
+			'args'        => array( 'title' => array( 'type' => 'string' ) ),
+		)) )['post']['parameters'];
+
+		$this->assertEquals( 'formData', $params[0]['in'] );
+		$this->assertEquals( 'string', $params[0]['type'] );
+	}
+
+	public function test_object_body_param_keeps_required_subproperties() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array(
+				'address' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'street' => array( 'type' => 'string', 'required' => true ),
+						'zip'    => array( 'type' => 'string' ),
+					),
+				),
+			),
+		)) )['post'];
+
+		$schema = $operation['parameters'][0]['schema'];
+		$this->assertEquals( array( 'street' ), $schema['properties']['address']['required'] );
+		$this->assertArrayNotHasKey( 'required', $schema['properties']['address']['properties']['street'] );
+		$this->assertArrayNotHasKey( 'required', $schema );
+	}
+
+	public function test_required_object_param_stays_in_body_required() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array(
+				'address' => array(
+					'type'       => 'object',
+					'required'   => true,
+					'properties' => array(
+						'street' => array( 'type' => 'string', 'required' => true ),
+					),
+				),
+			),
+		)) )['post'];
+
+		$schema = $operation['parameters'][0]['schema'];
+		$this->assertEquals( array( 'address' ), $schema['required'] );
+		$this->assertEquals( array( 'street' ), $schema['properties']['address']['required'] );
+		$this->assertArrayNotHasKey( 'objectRequired', $schema['properties']['address'] );
+	}
+
+	public function test_array_enum_places_choices_in_items() {
+		$params = $this->ui->buildParams( 'kinds', 'get', '/sample', array(
+			'type' => 'array',
+			'enum' => array( 'a', 'b', 'c' ),
+		) );
+
+		$this->assertEquals( 'array', $params['type'] );
+		$this->assertEquals( array( 'a', 'b', 'c' ), $params['items']['enum'] );
+		$this->assertArrayNotHasKey( 'enum', $params );
+		$this->assertEquals( 'multi', $params['collectionFormat'] );
+	}
+
+	public function test_typeless_properties_infer_object_schema() {
+		$schema = $this->ui->normalizeSchema( array(
+			'properties' => array( 'a' => array( 'type' => 'string' ) ),
+		) );
+
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'a', $schema['properties'] );
+	}
+
+	public function test_normalizeSchema_preserves_additional_properties() {
+		$schema = $this->ui->normalizeSchema( array(
+			'type'                 => 'object',
+			'additionalProperties' => array( 'type' => 'string' ),
+		) );
+
+		$this->assertEquals( array( 'type' => 'string' ), $schema['additionalProperties'] );
+	}
+
+	public function test_typeless_properties_survive_route_generation() {
+		$params = $this->ui->getParametersFromArgs( '/sample', array(
+			'config' => array( 'properties' => array( 'a' => array( 'type' => 'string' ) ) ),
+		), array( 'POST' => true ) )['post'];
+
+		$this->assertEquals( 'object', $params[0]['type'] );
+		$this->assertArrayHasKey( 'a', $params[0]['properties'] );
+	}
+
+	public function test_json_put_route_builds_body_parameter() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'PUT' => true ),
+			'accept_json' => true,
+			'args'        => array( 'title' => array( 'type' => 'string', 'required' => true ) ),
+		)) )['put'];
+
+		$this->assertEquals( 'body', $operation['parameters'][0]['in'] );
+		$this->assertArrayHasKey( 'title', $operation['parameters'][0]['schema']['properties'] );
+		$this->assertEquals( array( 'application/json' ), $operation['consumes'] );
+	}
+
+	public function test_object_level_required_array_is_preserved() {
+		$schema = $this->ui->normalizeSchema( array(
+			'type'       => 'object',
+			'required'   => array( 'street' ),
+			'properties' => array(
+				'street' => array( 'type' => 'string' ),
+				'zip'    => array( 'type' => 'string' ),
+			),
+		) );
+
+		$this->assertEquals( array( 'street' ), $schema['required'] );
+	}
+
+	public function test_object_level_required_array_not_treated_as_field_required() {
+		$params = $this->ui->buildParams( 'address', 'post', '/sample', array(
+			'type'       => 'object',
+			'required'   => array( 'street' ),
+			'properties' => array( 'street' => array( 'type' => 'string' ) ),
+		) );
+
+		$this->assertFalse( $params['required'] );
+		$this->assertEquals( array( 'street' ), $params['objectRequired'] );
+	}
+
+	public function test_additional_properties_schema_is_normalized() {
+		$schema = $this->ui->normalizeSchema( array(
+			'type'                 => 'object',
+			'additionalProperties' => array( 'type' => 'enum', 'enum' => array( 'a', 'b' ) ),
+		) );
+
+		$this->assertEquals( 'string', $schema['additionalProperties']['type'] );
+		$this->assertEquals( array( 'a', 'b' ), $schema['additionalProperties']['enum'] );
+	}
+
+	public function test_swagger2_invalid_keywords_are_dropped() {
+		$schema = $this->ui->normalizeSchema( array(
+			'type'  => 'string',
+			'oneOf' => array( array( 'type' => 'string' ) ),
+			'const' => 'x',
+		) );
+
+		$this->assertArrayNotHasKey( 'oneOf', $schema );
+		$this->assertArrayNotHasKey( 'const', $schema );
+	}
+
+	public function test_non_body_array_of_object_strips_incompatible_keywords() {
+		$params = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'GET' => true ),
+			'accept_json' => false,
+			'args'        => array( 'filters' => array(
+				'type'     => 'array',
+				'minItems' => 1,
+				'items'    => array( 'type' => 'object', 'properties' => array( 'k' => array( 'type' => 'string' ) ) ),
+			) ),
+		)) )['get']['parameters'];
+
+		$this->assertEquals( 'string', $params[0]['type'] );
+		$this->assertArrayNotHasKey( 'items', $params[0] );
+		$this->assertArrayNotHasKey( 'minItems', $params[0] );
+	}
+
+	public function test_json_get_object_query_param_is_downgraded() {
+		$params = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'GET' => true ),
+			'accept_json' => true,
+			'args'        => array( 'filter' => array( 'type' => 'object', 'properties' => array( 'a' => array( 'type' => 'string' ) ) ) ),
+		)) )['get']['parameters'];
+
+		$this->assertEquals( 'query', $params[0]['in'] );
+		$this->assertEquals( 'string', $params[0]['type'] );
+		$this->assertArrayNotHasKey( 'properties', $params[0] );
+	}
+
+	public function test_explicit_and_inferred_body_merge_into_one() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array(
+				'payload' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ) ) ),
+				'title'   => array( 'type' => 'string', 'required' => true ),
+			),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$this->assertCount( 1, $bodies );
+		$this->assertArrayHasKey( 'x', $bodies[0]['schema']['properties'] );
+		$this->assertArrayHasKey( 'title', $bodies[0]['schema']['properties'] );
+		$this->assertEquals( array( 'title' ), $bodies[0]['schema']['required'] );
+	}
+
+	public function test_explicit_body_param_carries_only_schema() {
+		$params = $this->ui->buildParams( 'payload', 'post', '/sample', array(
+			'in'     => 'body',
+			'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'enum', 'enum' => array( 'a' ) ) ) ),
+		) );
+
+		$this->assertEquals( 'body', $params['in'] );
+		$this->assertArrayHasKey( 'schema', $params );
+		$this->assertArrayNotHasKey( 'type', $params );
+		$this->assertArrayNotHasKey( 'items', $params );
+		$this->assertEquals( 'string', $params['schema']['properties']['x']['type'] );
+	}
+
+	public function test_json_route_with_file_keeps_form_data() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array( 'file' => array( 'type' => 'file' ) ),
+		)) )['post'];
+
+		$this->assertEquals( 'formData', $operation['parameters'][0]['in'] );
+		$this->assertEquals( 'file', $operation['parameters'][0]['type'] );
+		$this->assertContains( 'multipart/form-data', $operation['consumes'] );
+	}
+
+	public function test_ref_schema_is_preserved() {
+		$this->assertEquals(
+			array( '$ref' => '#/definitions/Thing' ),
+			$this->ui->normalizeSchema( array( '$ref' => '#/definitions/Thing' ) )
+		);
+		$nested = $this->ui->normalizeSchema( array( 'type' => 'array', 'items' => array( '$ref' => '#/definitions/Thing' ) ) );
+		$this->assertEquals( '#/definitions/Thing', $nested['items']['$ref'] );
+	}
+
+	public function test_composition_only_schema_has_no_string_type() {
+		$schema = $this->ui->normalizeSchema( array(
+			'allOf' => array( array( 'type' => 'object', 'properties' => array( 'a' => array( 'type' => 'string' ) ) ) ),
+		) );
+
+		$this->assertArrayNotHasKey( 'type', $schema );
+		$this->assertArrayHasKey( 'allOf', $schema );
+	}
+
+	public function test_union_type_with_null_selects_real_type() {
+		$object = $this->ui->normalizeSchema( array( 'type' => array( 'null', 'object' ), 'properties' => array( 'a' => array( 'type' => 'string' ) ) ) );
+		$this->assertEquals( 'object', $object['type'] );
+
+		$string = $this->ui->normalizeSchema( array( 'type' => array( 'string', 'null' ) ) );
+		$this->assertEquals( 'string', $string['type'] );
+	}
+
+	public function test_empty_additional_properties_stays_open() {
+		$schema = $this->ui->normalizeSchema( array( 'type' => 'object', 'additionalProperties' => array() ) );
+		$this->assertTrue( $schema['additionalProperties'] );
+	}
+
+	public function test_required_preserved_without_direct_properties() {
+		$schema = $this->ui->normalizeSchema( array(
+			'type'     => 'object',
+			'required' => array( 'street' ),
+			'allOf'    => array( array( 'properties' => array( 'street' => array( 'type' => 'string' ) ) ) ),
+		) );
+
+		$this->assertEquals( array( 'street' ), $schema['required'] );
+	}
+
+	public function test_typeless_id_argument_infers_integer() {
+		$params = $this->ui->getParametersFromArgs( '/sample', array(
+			'id'      => array(),
+			'post_id' => array(),
+			'title'   => array(),
+		), array( 'GET' => true ) )['get'];
+
+		$by_name = array();
+		foreach ( $params as $param ) {
+			$by_name[ $param['name'] ] = $param;
+		}
+		$this->assertEquals( 'integer', $by_name['id']['type'] );
+		$this->assertEquals( 'integer', $by_name['post_id']['type'] );
+		$this->assertEquals( 'string', $by_name['title']['type'] );
+	}
+
+	public function test_non_array_detail_does_not_error() {
+		$params = $this->ui->buildParams( 'title', 'get', '/sample', 'garbage' );
+		$this->assertEquals( 'string', $params['type'] );
+	}
+
+	public function test_required_only_schema_infers_object() {
+		$schema = $this->ui->normalizeSchema( array( 'required' => array( 'a' ) ) );
+		$this->assertEquals( 'object', $schema['type'] );
+		$this->assertEquals( array( 'a' ), $schema['required'] );
+	}
+
+	public function test_array_enum_default_moves_into_items() {
+		$params = $this->ui->buildParams( 'kind', 'get', '/sample', array(
+			'type'    => 'array',
+			'enum'    => array( 'a', 'b' ),
+			'default' => 'a',
+		) );
+
+		$this->assertEquals( 'a', $params['items']['default'] );
+		$this->assertArrayNotHasKey( 'default', $params );
+	}
+
+	public function test_nested_array_object_query_param_is_downgraded() {
+		$params = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'GET' => true ),
+			'accept_json' => false,
+			'args'        => array( 'grid' => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'array', 'items' => array( 'type' => 'object', 'properties' => array( 'k' => array( 'type' => 'string' ) ) ) ),
+			) ),
+		)) )['get']['parameters'];
+
+		$this->assertEquals( 'string', $params[0]['type'] );
+		$this->assertArrayNotHasKey( 'items', $params[0] );
+	}
+
+	public function test_merged_required_field_makes_body_required() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array(
+				'payload' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ) ) ),
+				'title'   => array( 'type' => 'string', 'required' => true ),
+			),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$this->assertCount( 1, $bodies );
+		$this->assertTrue( $bodies[0]['required'] );
+	}
+
+	public function test_non_object_explicit_body_is_not_merged() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array(
+				'items' => array( 'in' => 'body', 'schema' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ) ),
+				'title' => array( 'type' => 'string' ),
+			),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$this->assertCount( 1, $bodies );
+		$this->assertEquals( 'array', $bodies[0]['schema']['type'] );
+		$this->assertArrayNotHasKey( 'properties', $bodies[0]['schema'] );
+	}
+
+	public function test_two_explicit_bodies_collapse_to_one() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => false,
+			'args'        => array(
+				'a' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ) ) ),
+				'b' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'y' => array( 'type' => 'string' ) ) ) ),
+			),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$this->assertCount( 1, $bodies );
+		$this->assertArrayHasKey( 'x', $bodies[0]['schema']['properties'] );
+		$this->assertArrayHasKey( 'y', $bodies[0]['schema']['properties'] );
+	}
+
+	public function test_non_json_body_absorbs_form_fields() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => false,
+			'args'        => array(
+				'payload' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ) ) ),
+				'title'   => array( 'type' => 'string' ),
+			),
+		)) )['post'];
+
+		$ins = array_map( function ( $p ) { return $p['in']; }, $operation['parameters'] );
+		$this->assertNotContains( 'formData', $ins );
+		$this->assertContains( 'body', $ins );
+		$this->assertContains( 'application/json', $operation['consumes'] );
+	}
+
+	public function test_file_route_drops_json_consume() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array( 'file' => array( 'type' => 'file' ) ),
+		)) )['post'];
+
+		$this->assertNotContains( 'application/json', $operation['consumes'] );
+		$this->assertContains( 'multipart/form-data', $operation['consumes'] );
+		$this->assertEquals( 'file', $operation['parameters'][0]['type'] );
+	}
+
+	public function test_nested_file_field_prevents_json_body() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array( 'upload' => array(
+				'type'       => 'object',
+				'properties' => array( 'doc' => array( 'type' => 'file' ) ),
+			) ),
+		)) )['post'];
+
+		$this->assertNotContains( 'application/json', $operation['consumes'] );
+		$ins = array_map( function ( $p ) { return $p['in']; }, $operation['parameters'] );
+		$this->assertNotContains( 'body', $ins );
+	}
+
+	public function test_file_inside_composition_prevents_json_body() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array( 'doc' => array(
+				'allOf' => array( array( 'type' => 'object', 'properties' => array( 'f' => array( 'type' => 'file' ) ) ) ),
+			) ),
+		)) )['post'];
+
+		$this->assertNotContains( 'application/json', $operation['consumes'] );
+	}
+
+	public function test_file_route_consumes_multipart_only() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array( 'file' => array( 'type' => 'file' ) ),
+		)) )['post'];
+
+		$this->assertEquals( array( 'multipart/form-data' ), $operation['consumes'] );
+	}
+
+	public function test_xml_only_body_not_broadened_to_json() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => false,
+			'consumes'    => array( 'application/xml' ),
+			'args'        => array( 'payload' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ) ) ) ),
+		)) )['post'];
+
+		$this->assertContains( 'application/xml', $operation['consumes'] );
+		$this->assertNotContains( 'application/json', $operation['consumes'] );
+	}
+
+	public function test_openapi3_moves_definitions_and_rewrites_refs() {
+		$openapi = ( new Spec30Formatter() )->format(array(
+			'host'        => 'example.org',
+			'basePath'    => '/wp-json',
+			'schemes'     => array( 'https' ),
+			'definitions' => array( 'Thing' => array( 'type' => 'object', 'properties' => array( 'a' => array( 'type' => 'string' ) ) ) ),
+			'paths'       => array( '/sample' => array( 'post' => array(
+				'consumes'   => array( 'application/json' ),
+				'parameters' => array( array( 'name' => 'body', 'in' => 'body', 'schema' => array( '$ref' => '#/definitions/Thing' ) ) ),
+				'responses'  => array( '200' => array( 'description' => 'OK' ) ),
+			) ) ),
+		));
+
+		$this->assertArrayHasKey( 'Thing', $openapi['components']['schemas'] );
+		$this->assertArrayNotHasKey( 'definitions', $openapi );
+		$ref = $openapi['paths']['/sample']['post']['requestBody']['content']['application/json']['schema']['$ref'];
+		$this->assertEquals( '#/components/schemas/Thing', $ref );
+	}
+
+	public function test_openapi3_normalizes_nested_file_to_binary() {
+		$openapi = ( new Spec30Formatter() )->format(array(
+			'host'     => 'example.org',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https' ),
+			'paths'    => array( '/sample' => array( 'post' => array(
+				'consumes'   => array( 'multipart/form-data' ),
+				'parameters' => array(
+					array( 'name' => 'upload', 'in' => 'formData', 'type' => 'object', 'properties' => array(
+						'doc' => array( 'type' => 'file', 'description' => 'the file' ),
+					) ),
+				),
+				'responses'  => array( '200' => array( 'description' => 'OK' ) ),
+			) ) ),
+		));
+
+		$doc = $openapi['paths']['/sample']['post']['requestBody']['content']['multipart/form-data']['schema']['properties']['upload']['properties']['doc'];
+		$this->assertEquals( 'string', $doc['type'] );
+		$this->assertEquals( 'binary', $doc['format'] );
+		$this->assertEquals( 'the file', $doc['description'] );
+	}
+
+	public function test_query_param_with_raw_object_schema_is_downgraded() {
+		$params = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'GET' => true ),
+			'accept_json' => false,
+			'args'        => array( 'filter' => array( 'schema' => array( 'type' => 'object', 'properties' => array( 'a' => array( 'type' => 'string' ) ) ) ) ),
+		)) )['get']['parameters'];
+
+		$this->assertEquals( 'string', $params[0]['type'] );
+		$this->assertArrayNotHasKey( 'schema', $params[0] );
+	}
+
+	public function test_parseTypeObjectToString_backward_compatible() {
+		$this->assertEquals( 'string', $this->ui->parseTypeObjectToString( 'object' ) );
+		$this->assertEquals( 'integer', $this->ui->parseTypeObjectToString( 'integer' ) );
+		$this->assertEquals( 'string', $this->ui->parseTypeObjectToString( array( 'object', 'null' ) ) );
+	}
+
 	public function test_buildParameters() {
 		$this->assertTrue( is_array( $this->ui->getParametersFromArgs( '/sample/{id}', [], [] ) ) );
 	}

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -652,6 +652,53 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$this->assertEquals( 'string', $this->ui->parseTypeObjectToString( array( 'object', 'null' ) ) );
 	}
 
+	public function test_ref_body_property_has_no_string_type() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array( 'thing' => array( '$ref' => '#/definitions/Thing' ) ),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$prop = $bodies[0]['schema']['properties']['thing'];
+		$this->assertEquals( '#/definitions/Thing', $prop['$ref'] );
+		$this->assertArrayNotHasKey( 'type', $prop );
+	}
+
+	public function test_composition_body_property_has_no_string_type() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array( 'thing' => array( 'allOf' => array( array( 'type' => 'object', 'properties' => array( 'a' => array( 'type' => 'string' ) ) ) ) ) ),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$prop = $bodies[0]['schema']['properties']['thing'];
+		$this->assertArrayHasKey( 'allOf', $prop );
+		$this->assertArrayNotHasKey( 'type', $prop );
+	}
+
+	public function test_file_plus_explicit_body_keeps_body_schema() {
+		$operation = $this->ui->getMethodsFromArgs( '/sample', '/wp/v2/sample', array(array(
+			'methods'     => array( 'POST' => true ),
+			'accept_json' => true,
+			'args'        => array(
+				'file' => array( 'type' => 'file' ),
+				'meta' => array( 'in' => 'body', 'schema' => array( 'type' => 'object', 'properties' => array( 'x' => array( 'type' => 'string' ) ) ) ),
+			),
+		)) )['post'];
+
+		$bodies = array_values( array_filter( $operation['parameters'], function ( $p ) {
+			return isset( $p['in'] ) && 'body' === $p['in'];
+		} ) );
+		$this->assertCount( 1, $bodies );
+		$this->assertArrayHasKey( 'x', $bodies[0]['schema']['properties'] );
+	}
+
 	public function test_buildParameters() {
 		$this->assertTrue( is_array( $this->ui->getParametersFromArgs( '/sample/{id}', [], [] ) ) );
 	}

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -268,7 +268,12 @@ class WP_API_SwaggerUI
                 if ($has_file) {
                     // Swagger 2 file parameters are valid only under multipart/form-data.
                     $consumes = ['multipart/form-data'];
-                    $parameters = array_map([$this, 'normalizeNonBodyParameter'], $parameters);
+                    foreach ($parameters as $index => $parameter) {
+                        // Leave an explicit body schema intact; only downgrade non-body params.
+                        if (!isset($parameter['in']) || 'body' !== $parameter['in']) {
+                            $parameters[$index] = $this->normalizeNonBodyParameter($parameter);
+                        }
+                    }
                 } elseif ($wants_json || $has_explicit_body) {
                     // Consolidate form fields into the single body parameter Swagger 2 allows.
                     $parameters = $this->buildJsonBodyParameter($parameters);
@@ -369,7 +374,9 @@ class WP_API_SwaggerUI
             $detail = array();
         }
         $schema = $this->normalizeSchema($detail);
-        $type = isset($schema['type']) ? $schema['type'] : 'string';
+        // Null when normalizeSchema intentionally omits type ($ref or composition-only);
+        // forcing 'string' here would contradict the $ref/allOf once folded into a body.
+        $type = isset($schema['type']) ? $schema['type'] : null;
 
         $in = $this->detectIn($param, $mtd, $endpoint, $detail);
         // A JSON-Schema `required` array is the object's schema-level list, not field requiredness.
@@ -401,8 +408,10 @@ class WP_API_SwaggerUI
             'in' => $in,
             'description' => isset($detail['description']) ? $detail['description'] : '',
             'required' => $required,
-            'type' => $type
         );
+        if (null !== $type) {
+            $params['type'] = $type;
+        }
 
         foreach ($schema as $key => $value) {
             if ('description' !== $key && 'required' !== $key && 'type' !== $key) {

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -505,7 +505,7 @@ class WP_API_SwaggerUI
 
         // Keep only keywords valid in Swagger 2.0 (the base spec this plugin emits).
         // oneOf/anyOf/const/patternProperties are not; dropping beats emitting invalid output.
-        $keys = array('description', 'format', 'enum', 'default', 'example', 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'multipleOf', 'minLength', 'maxLength', 'pattern', 'minItems', 'maxItems', 'uniqueItems', 'minProperties', 'maxProperties', 'title');
+        $keys = array('description', 'format', 'enum', 'default', 'example', 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'multipleOf', 'minLength', 'maxLength', 'pattern', 'minItems', 'maxItems', 'uniqueItems', 'minProperties', 'maxProperties', 'title', 'xml');
         foreach ($keys as $key) {
             if (array_key_exists($key, $detail)) {
                 $schema[$key] = $detail[$key];
@@ -685,6 +685,10 @@ class WP_API_SwaggerUI
                 unset($parameter[$key]);
             }
         }
+        // Swagger 2 Parameter Objects (non-body) permit only a fixed key subset; schema-only
+        // metadata such as title/example/xml is invalid here and must not leak through.
+        $allowed = array('name', 'in', 'description', 'required', 'type', 'format', 'allowEmptyValue', 'items', 'collectionFormat', 'default', 'maximum', 'exclusiveMaximum', 'minimum', 'exclusiveMinimum', 'maxLength', 'minLength', 'pattern', 'maxItems', 'minItems', 'uniqueItems', 'enum', 'multipleOf');
+        $parameter = array_intersect_key($parameter, array_flip($allowed));
         // A string parameter cannot carry an array default left over from the downgrade.
         if (isset($parameter['type']) && 'string' === $parameter['type'] && isset($parameter['default']) && is_array($parameter['default'])) {
             unset($parameter['default']);

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -253,6 +253,46 @@ class WP_API_SwaggerUI
                     $consumes[] = 'application/json';
                 }
 
+                $has_file = false;
+                $has_explicit_body = false;
+                foreach ($parameters as $parameter) {
+                    if ($this->schemaContainsFile($parameter)) {
+                        $has_file = true;
+                    }
+                    if (isset($parameter['in']) && 'body' === $parameter['in']) {
+                        $has_explicit_body = true;
+                    }
+                }
+                $wants_json = in_array('application/json', $consumes, true);
+
+                if ($has_file) {
+                    // Swagger 2 file parameters are valid only under multipart/form-data.
+                    $consumes = ['multipart/form-data'];
+                    $parameters = array_map([$this, 'normalizeNonBodyParameter'], $parameters);
+                } elseif ($wants_json || $has_explicit_body) {
+                    // Consolidate form fields into the single body parameter Swagger 2 allows.
+                    $parameters = $this->buildJsonBodyParameter($parameters);
+                    $has_body = false;
+                    foreach ($parameters as $index => $parameter) {
+                        if (isset($parameter['in']) && 'body' === $parameter['in']) {
+                            $has_body = true;
+                        } else {
+                            // Query/header params still cannot carry object schemas in Swagger 2.
+                            $parameters[$index] = $this->normalizeNonBodyParameter($parameter);
+                        }
+                    }
+                    // A body parameter cannot coexist with form media types. Drop those, but keep
+                    // any declared body-compatible type (e.g. XML); only default to JSON if none remain.
+                    if ($has_body) {
+                        $consumes = array_values(array_diff($consumes, ['application/x-www-form-urlencoded', 'multipart/form-data']));
+                        if (empty($consumes)) {
+                            $consumes = ['application/json'];
+                        }
+                    }
+                } else {
+                    $parameters = array_map([$this, 'normalizeNonBodyParameter'], $parameters);
+                }
+
                 $responses =$this->getResponses($methodEndpoint);
                 if (isset($arg['responses'])) {
                     $responses = $arg['responses'];
@@ -311,6 +351,8 @@ class WP_API_SwaggerUI
                 $in = 'path';
                 break;
             case 'post':
+            case 'put':
+            case 'patch':
                 $in = 'formData';
                 break;
             default:
@@ -321,40 +363,34 @@ class WP_API_SwaggerUI
         return $in;
     }
 
-    public function parseTypeObjectToString($types)
-    {
-        if (is_array($types)) {
-            foreach ($types as $type) {
-                return $this->parseTypeObjectToString($type);
-            }
-        }
-        return $types === 'object' ? 'string' : $types;
-    }
-
     public function buildParams($param, $mtd, $endpoint, $detail)
     {
-        /**
-         * When the type is object, SwaggerUI by default add empty `{}` to parameter value
-         * It's annoying so need to convert to just `string`
-         */
-        $type = $this->parseTypeObjectToString($detail['type']);
-        if (is_array($type) && isset($type[0])) {
-            $type = $type[0];
+        if (!is_array($detail)) {
+            $detail = array();
         }
-
-        if (empty($type)) {
-
-            if (strpos($param, '_id') !== false) {
-                $type = 'integer';
-            } elseif (strtolower($param) === 'id') {
-                $type = 'integer';
-            } else {
-                $type = 'string';
-            }
-        }
+        $schema = $this->normalizeSchema($detail);
+        $type = isset($schema['type']) ? $schema['type'] : 'string';
 
         $in = $this->detectIn($param, $mtd, $endpoint, $detail);
-        $required = !empty($detail['required']);
+        // A JSON-Schema `required` array is the object's schema-level list, not field requiredness.
+        $required = !empty($detail['required']) && !is_array($detail['required']);
+
+        // Swagger 2 body parameters carry their schema under `schema`, not primitive fields.
+        if ('body' === $in) {
+            return array(
+                'name' => $param,
+                'in' => 'body',
+                'description' => isset($detail['description']) ? $detail['description'] : '',
+                'required' => $required,
+                'schema' => isset($detail['schema']) ? $this->normalizeSchema($detail['schema']) : $schema,
+            );
+        }
+
+        // Typeless `id` / `*_id` arguments are conventionally integers.
+        if (!isset($detail['type']) && 'string' === $type
+            && ('id' === strtolower($param) || false !== strpos($param, '_id'))) {
+            $type = 'integer';
+        }
 
         if ('path' === $in) {
             $required = true;
@@ -368,42 +404,316 @@ class WP_API_SwaggerUI
             'type' => $type
         );
 
-        if (isset($detail['items'])) {
-            $params['items'] = array(
-                'type' => isset($detail['items']['type']) ? $detail['items']['type'] : 'string'
-            );
-        } elseif (isset($detail['enum'])) {
-            $params['type'] = 'array';
-            $items = array(
-                'type' => $detail['type'],
-                'enum' => $detail['enum']
-            );
-            if (isset($detail['default'])) {
-                $items['default'] = $detail['default'];
+        foreach ($schema as $key => $value) {
+            if ('description' !== $key && 'required' !== $key && 'type' !== $key) {
+                $params[$key] = $value;
             }
-            $params['items'] = $items;
+        }
+
+        // Object sub-property requirements are schema-level; carry them separately so the
+        // param's own boolean requiredness ($params['required']) is preserved.
+        if ('object' === $type && isset($schema['required'])) {
+            $params['objectRequired'] = $schema['required'];
+        }
+
+        if ('array' === $type && isset($detail['enum']) && !isset($detail['items'])) {
             $params['collectionFormat'] = 'multi';
         }
 
-        if (isset($detail['maximum'])) {
-            $params['maximum'] = $detail['maximum'];
-        }
-
-        if (isset($detail['minimum'])) {
-            $params['minimum'] = $detail['minimum'];
-        }
-
-        if (isset($detail['format'])) {
-            $params['format'] = $detail['format'];
-        } elseif ($detail['type'] === 'integer') {
+        if ('integer' === $type && !isset($params['format'])) {
             $params['format'] = 'int64';
         }
 
-        if (isset($detail['schema'])) {
-            $params['schema'] = $detail['schema'];
+        return $params;
+    }
+
+    /**
+     * @deprecated Use normalizeSchema() instead. Retained for backward compatibility.
+     */
+    public function parseTypeObjectToString($types)
+    {
+        if (is_array($types)) {
+            foreach ($types as $type) {
+                return $this->parseTypeObjectToString($type);
+            }
+        }
+        return 'object' === $types ? 'string' : $types;
+    }
+
+    /** Normalize a WordPress REST argument into a recursively complete schema. */
+    public function normalizeSchema($detail)
+    {
+        if (!is_array($detail)) {
+            return array('type' => 'string');
         }
 
-        return $params;
+        // A $ref replaces the schema; it carries no sibling keywords.
+        if (isset($detail['$ref'])) {
+            return array('$ref' => $detail['$ref']);
+        }
+
+        $schema = array();
+        $type = null;
+        if (isset($detail['type'])) {
+            $type = $detail['type'];
+            if (is_array($type)) {
+                // Union types: drop the non-representable "null" and keep the first real type.
+                $type = array_values(array_filter($type, function ($member) {
+                    return 'null' !== $member;
+                }));
+                $type = !empty($type) ? reset($type) : 'string';
+            }
+            // Some routes use the non-standard type "enum". Keep their intent valid.
+            $type = ('enum' === $type) ? 'string' : ($type ?: 'string');
+        } elseif (isset($detail['properties'])) {
+            $type = 'object';
+        } elseif (isset($detail['items'])) {
+            $type = 'array';
+        } elseif (isset($detail['allOf'])) {
+            $type = null; // composition-only schema has no primitive type
+        } elseif ((isset($detail['required']) && is_array($detail['required'])) || isset($detail['additionalProperties']) || isset($detail['minProperties']) || isset($detail['maxProperties'])) {
+            $type = 'object'; // object-only keywords imply an object
+        } else {
+            $type = 'string';
+        }
+        if (null !== $type) {
+            $schema['type'] = $type;
+        }
+
+        // Keep only keywords valid in Swagger 2.0 (the base spec this plugin emits).
+        // oneOf/anyOf/const/patternProperties are not; dropping beats emitting invalid output.
+        $keys = array('description', 'format', 'enum', 'default', 'example', 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', 'multipleOf', 'minLength', 'maxLength', 'pattern', 'minItems', 'maxItems', 'uniqueItems', 'minProperties', 'maxProperties', 'title');
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $detail)) {
+                $schema[$key] = $detail[$key];
+            }
+        }
+
+        if (isset($detail['additionalProperties'])) {
+            $additional = $detail['additionalProperties'];
+            if (is_array($additional)) {
+                // Empty schema {} means "any value"; keep it open rather than narrowing to string.
+                $schema['additionalProperties'] = empty($additional) ? true : $this->normalizeSchema($additional);
+            } else {
+                $schema['additionalProperties'] = $additional;
+            }
+        }
+        if (isset($detail['allOf']) && is_array($detail['allOf'])) {
+            $schema['allOf'] = array_map(array($this, 'normalizeSchema'), $detail['allOf']);
+        }
+
+        if (isset($detail['items'])) {
+            $schema['items'] = $this->normalizeSchema($detail['items']);
+        } elseif ('array' === $type) {
+            $items = array('type' => 'string');
+            if (isset($schema['enum'])) {
+                $items['enum'] = $schema['enum'];
+                unset($schema['enum']);
+                // The scalar default constrains items, not the array itself.
+                if (isset($schema['default']) && !is_array($schema['default'])) {
+                    $items['default'] = $schema['default'];
+                    unset($schema['default']);
+                }
+            }
+            $schema['items'] = $items;
+        }
+
+        // Object-level required (JSON Schema array) applies even when properties arrive via allOf.
+        $required = (isset($detail['required']) && is_array($detail['required'])) ? $detail['required'] : array();
+        if (isset($detail['properties']) && is_array($detail['properties'])) {
+            $schema['properties'] = array();
+            foreach ($detail['properties'] as $name => $property) {
+                $schema['properties'][$name] = $this->normalizeSchema($property);
+                if (is_array($property) && !empty($property['required']) && !is_array($property['required'])) {
+                    $required[] = $name;
+                }
+            }
+        }
+        $required = array_values(array_unique($required));
+        if (!empty($required)) {
+            $schema['required'] = $required;
+        }
+
+        return $schema;
+    }
+
+    /** Combine inferred form fields into the one body parameter Swagger 2 supports. */
+    public function buildJsonBodyParameter($parameters)
+    {
+        $ordinary = array();
+        $properties = array();
+        $required = array();
+
+        foreach ($parameters as $parameter) {
+            if (!isset($parameter['in']) || 'formData' !== $parameter['in']) {
+                $ordinary[] = $parameter;
+                continue;
+            }
+            $name = $parameter['name'];
+            $field_required = !empty($parameter['required']);
+            $schema = $parameter;
+            foreach (array('name', 'in', 'required', 'collectionFormat', 'objectRequired') as $key) {
+                unset($schema[$key]);
+            }
+            if (isset($parameter['objectRequired'])) {
+                $schema['required'] = $parameter['objectRequired'];
+            }
+            $properties[$name] = $schema;
+            if ($field_required) {
+                $required[] = $name;
+            }
+        }
+
+        // Swagger 2 permits a single body parameter: collapse multiple explicit ones into the first.
+        $bodyIndex = null;
+        foreach ($ordinary as $index => $parameter) {
+            if (!isset($parameter['in']) || 'body' !== $parameter['in']) {
+                continue;
+            }
+            if (null === $bodyIndex) {
+                $bodyIndex = $index;
+                continue;
+            }
+            if ($this->bodySchemaIsObjectCompatible($this->bodySchema($ordinary[$bodyIndex]))
+                && $this->bodySchemaIsObjectCompatible($this->bodySchema($parameter))) {
+                $ordinary[$bodyIndex]['schema'] = $this->mergeObjectSchema($this->bodySchema($ordinary[$bodyIndex]), $this->bodySchema($parameter));
+                if (!empty($parameter['required'])) {
+                    $ordinary[$bodyIndex]['required'] = true;
+                }
+            }
+            unset($ordinary[$index]);
+        }
+        $ordinary = array_values($ordinary);
+
+        if (empty($properties)) {
+            return $ordinary;
+        }
+
+        // Merge inferred form fields into an existing body when it is object-compatible.
+        foreach ($ordinary as $index => $parameter) {
+            if (!isset($parameter['in']) || 'body' !== $parameter['in']) {
+                continue;
+            }
+            if (!$this->bodySchemaIsObjectCompatible($this->bodySchema($parameter))) {
+                return $ordinary; // cannot fold form fields into a non-object body
+            }
+            $ordinary[$index]['schema'] = $this->mergeObjectSchema($this->bodySchema($parameter), array('properties' => $properties, 'required' => $required));
+            if (!empty($required)) {
+                $ordinary[$index]['required'] = true;
+            }
+            return $ordinary;
+        }
+
+        $schema = array('type' => 'object', 'properties' => $properties);
+        if (!empty($required)) {
+            $schema['required'] = $required;
+        }
+        $ordinary[] = array(
+            'name' => 'body',
+            'in' => 'body',
+            'description' => '',
+            'required' => !empty($required),
+            'schema' => $schema,
+        );
+
+        return $ordinary;
+    }
+
+    private function bodySchema($parameter)
+    {
+        return isset($parameter['schema']) && is_array($parameter['schema']) ? $parameter['schema'] : array();
+    }
+
+    /** An object body can absorb inferred form fields; a $ref, allOf, or scalar/array body cannot. */
+    private function bodySchemaIsObjectCompatible($schema)
+    {
+        if (isset($schema['$ref']) || isset($schema['allOf'])) {
+            return false;
+        }
+        return !isset($schema['type']) || 'object' === $schema['type'];
+    }
+
+    /** Merge one object body schema's properties and required list into another. */
+    private function mergeObjectSchema($target, $source)
+    {
+        $target['type'] = 'object';
+        if (!isset($target['properties']) || !is_array($target['properties'])) {
+            $target['properties'] = array();
+        }
+        if (isset($source['properties']) && is_array($source['properties'])) {
+            $target['properties'] += $source['properties'];
+        }
+        $required = isset($target['required']) && is_array($target['required']) ? $target['required'] : array();
+        if (isset($source['required']) && is_array($source['required'])) {
+            $required = array_merge($required, $source['required']);
+        }
+        if (!empty($required)) {
+            $target['required'] = array_values(array_unique($required));
+        }
+        return $target;
+    }
+
+    /** Swagger 2 query/form parameters cannot carry object or reference schemas at any depth. */
+    public function normalizeNonBodyParameter($parameter)
+    {
+        if ($this->schemaIsStructured($parameter)) {
+            $parameter['type'] = 'string';
+            foreach (array('properties', 'objectRequired', 'additionalProperties', 'allOf', '$ref', 'items', 'schema', 'collectionFormat', 'minProperties', 'maxProperties', 'minItems', 'maxItems', 'uniqueItems') as $key) {
+                unset($parameter[$key]);
+            }
+        }
+        // A string parameter cannot carry an array default left over from the downgrade.
+        if (isset($parameter['type']) && 'string' === $parameter['type'] && isset($parameter['default']) && is_array($parameter['default'])) {
+            unset($parameter['default']);
+        }
+        return $parameter;
+    }
+
+    /** A query/form schema is unrepresentable in Swagger 2 if it nests an object or $ref. */
+    private function schemaIsStructured($schema)
+    {
+        if (!is_array($schema)) {
+            return false;
+        }
+        if (isset($schema['$ref']) || isset($schema['properties']) || isset($schema['additionalProperties']) || isset($schema['allOf'])) {
+            return true;
+        }
+        if (isset($schema['type']) && 'object' === $schema['type']) {
+            return true;
+        }
+        if (isset($schema['schema']) && $this->schemaIsStructured($schema['schema'])) {
+            return true;
+        }
+        if (isset($schema['items'])) {
+            return $this->schemaIsStructured($schema['items']);
+        }
+        return false;
+    }
+
+    /** Detect a Swagger 2 `file` type anywhere in a built parameter tree. */
+    private function schemaContainsFile($schema)
+    {
+        if (!is_array($schema)) {
+            return false;
+        }
+        if (isset($schema['type']) && 'file' === $schema['type']) {
+            return true;
+        }
+        foreach (array('items', 'schema', 'additionalProperties') as $key) {
+            if (isset($schema[$key]) && $this->schemaContainsFile($schema[$key])) {
+                return true;
+            }
+        }
+        foreach (array('properties', 'allOf') as $key) {
+            if (isset($schema[$key]) && is_array($schema[$key])) {
+                foreach ($schema[$key] as $sub) {
+                    if ($this->schemaContainsFile($sub)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     public function getParametersFromArgs($endpoint = '', $args = [], $methods = [])
@@ -418,7 +728,7 @@ class WP_API_SwaggerUI
                     $parameters[$mtd] = [];
                 }
 
-                $parameters[$mtd][] = $this->buildParams($param, $mtd, $endpoint, $detail + ['type' => 'string']);
+                $parameters[$mtd][] = $this->buildParams($param, $mtd, $endpoint, $detail);
             }
         }
 

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -266,14 +266,28 @@ class WP_API_SwaggerUI
                 $wants_json = in_array('application/json', $consumes, true);
 
                 if ($has_file) {
-                    // Swagger 2 file parameters are valid only under multipart/form-data.
+                    // Swagger 2 file parameters are valid only under multipart/form-data, and a
+                    // body parameter cannot coexist with formData. Flatten an explicit object body
+                    // into individual multipart fields and drop the body parameter.
                     $consumes = ['multipart/form-data'];
-                    foreach ($parameters as $index => $parameter) {
-                        // Leave an explicit body schema intact; only downgrade non-body params.
-                        if (!isset($parameter['in']) || 'body' !== $parameter['in']) {
-                            $parameters[$index] = $this->normalizeNonBodyParameter($parameter);
+                    $flattened = array();
+                    foreach ($parameters as $parameter) {
+                        if (isset($parameter['in']) && 'body' === $parameter['in']) {
+                            $schema = isset($parameter['schema']) && is_array($parameter['schema']) ? $parameter['schema'] : array();
+                            $props = isset($schema['properties']) && is_array($schema['properties']) ? $schema['properties'] : array();
+                            $body_required = isset($schema['required']) && is_array($schema['required']) ? $schema['required'] : array();
+                            foreach ($props as $name => $property) {
+                                $field = is_array($property) ? $property : array();
+                                $field['name'] = $name;
+                                $field['in'] = 'formData';
+                                $field['required'] = in_array($name, $body_required, true);
+                                $flattened[] = $this->normalizeNonBodyParameter($field);
+                            }
+                            continue;
                         }
+                        $flattened[] = $this->normalizeNonBodyParameter($parameter);
                     }
+                    $parameters = $flattened;
                 } elseif ($wants_json || $has_explicit_body) {
                     // Consolidate form fields into the single body parameter Swagger 2 allows.
                     $parameters = $this->buildJsonBodyParameter($parameters);

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: WP API SwaggerUI
  * Description: WordPress REST API with Swagger UI.
- * Version:     2.2.0
+ * Version:     2.3.0
  * Author:      Agus Suroyo
  * Requires PHP: 7.4
  * License:     GPL v2 or later


### PR DESCRIPTION
## Problem

Nested object properties were not shown in Swagger UI — an array-of-object argument rendered as a blank input instead of its declared properties. Reported at https://wordpress.org/support/topic/properties-of-objects-are-not-shown/

## Change

Recursively normalize WordPress REST argument schemas and emit spec-valid parameters.

**`normalizeSchema()`** — recurse `properties`/`items`/`additionalProperties`/`allOf`; honor object-level `required` arrays; `$ref` passthrough; filter `null` from union types; composition-only schemas carry no forced `string` type; move array `enum` into `items`; drop keywords invalid in Swagger 2.0 (`oneOf`/`anyOf`/`const`/`patternProperties`).

**`getMethodsFromArgs()`** — fold form fields into the single body Swagger 2 allows (POST/PUT/PATCH); keep file uploads on `multipart/form-data`; recursively downgrade structured query/form params; preserve declared body-compatible media types (e.g. XML).

**`buildJsonBodyParameter()`** — merge inferred fields into / collapse multiple explicit bodies down to one; set body `required`; guard non-object bodies.

**`Spec30Formatter`** — move top-level `definitions` to `components.schemas`; rewrite `#/definitions/…` → `#/components/schemas/…`; recursive `type:file` → `string`/`binary`.

**BC** — `parseTypeObjectToString()` restored as a `@deprecated` wrapper.

## Tests

+40 tests. Suite: **133 tests, 299 assertions**, all passing via wp-env (PHP 8.3).

## Known limitations (deliberate)

Degenerate/speculative inputs left unhandled: mixing an explicit non-object body with form fields, two incompatible explicit bodies, files nested inside an explicit body, empty `{}` schemas (kept as valid `string`), and OpenAPI 3 `nullable` from union types. None occur in real WordPress routes; all current output is valid Swagger 2.0 / OpenAPI 3.0.