### PR TITLE
feat: emit permalink-independent endpoint URLs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/agussuroyo
 Tags: swaggerui, wp swaggerui, wp rest api, wp swagger rest api, swaggerui rest api, swagger rest api, wp swagger, api, swagger, rest api
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 2.3.0
+Stable tag: 2.4.0
 Requires PHP: 7.4
 License: GPL v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -40,6 +40,9 @@ This plugin can be installed directly from your site.
 2. Options to choose namespace Rest API
 
 == Changelog ==
+
+= 2.4.0 =
+* Serve the docs and schema on all permalink types via `?swagger_api=docs` / `?swagger_api=schema`, not only pretty permalinks (the interactive Try-it-out feature still requires pretty permalinks)
 
 = 2.3.0 =
 * Fix nested object and array item properties not showing in Swagger UI (recursive schema normalization)

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ This plugin can be installed directly from your site.
 
 = 2.4.0 =
 * Serve the docs and schema on all permalink types via `?swagger_api=docs` / `?swagger_api=schema`, not only pretty permalinks
-* Make the interactive Try-it-out work under Plain permalinks by rewriting REST requests to the `?rest_route=` form
+* Make the interactive Try-it-out work under Plain permalinks by rewriting REST requests to the `?rest_route=` form; the OpenAPI 3.0.3 server URL now advertises that same form so it matches the request that is sent
 
 = 2.3.0 =
 * Fix nested object and array item properties not showing in Swagger UI (recursive schema normalization)

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,8 @@ This plugin can be installed directly from your site.
 == Changelog ==
 
 = 2.4.0 =
-* Serve the docs and schema on all permalink types via `?swagger_api=docs` / `?swagger_api=schema`, not only pretty permalinks (the interactive Try-it-out feature still requires pretty permalinks)
+* Serve the docs and schema on all permalink types via `?swagger_api=docs` / `?swagger_api=schema`, not only pretty permalinks
+* Make the interactive Try-it-out work under Plain permalinks by rewriting REST requests to the `?rest_route=` form
 
 = 2.3.0 =
 * Fix nested object and array item properties not showing in Swagger UI (recursive schema normalization)

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -13,4 +13,19 @@ SwaggerUIBundle({
     ],
     layout: "StandaloneLayout",
     validatorUrl: "https://validator.swagger.io/validator",
+    requestInterceptor: (req) => {
+        // Plain permalinks have no /wp-json route, so rewrite REST calls to
+        // the ?rest_route= form. Only touch requests under the REST base path;
+        // the schema fetch (?swagger_api=schema) is left alone.
+        const cfg = swagger_ui_app.rest_route;
+        if (cfg && cfg.enabled) {
+            const u = new URL(req.url);
+            if (cfg.basePath && u.pathname.indexOf(cfg.basePath) === 0) {
+                const route = u.pathname.slice(cfg.basePath.length);
+                const query = u.search ? u.search.slice(1) : '';
+                req.url = cfg.restRoot + '?rest_route=' + route + (query ? '&' + query : '');
+            }
+        }
+        return req;
+    },
 });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -28,8 +28,15 @@ SwaggerUIBundle({
         if (u.origin !== base.origin || u.searchParams.has('swagger_api')) {
             return req;
         }
+        // Only rewrite calls under the REST base path, so same-origin non-REST
+        // requests (e.g. an OAuth2 tokenUrl) are left untouched. When cfg.strip
+        // is just '/' (rare bare-root installs) we can't distinguish, so fall
+        // back to rewriting; the schema fetch stays safe via the guard above.
         let route = u.pathname;
-        if (cfg.strip && cfg.strip !== '/' && route.indexOf(cfg.strip) === 0) {
+        if (cfg.strip && cfg.strip !== '/') {
+            if (route.indexOf(cfg.strip) !== 0) {
+                return req;
+            }
             route = route.slice(cfg.strip.length);
         }
         const query = u.search ? u.search.slice(1) : '';

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -15,17 +15,25 @@ SwaggerUIBundle({
     validatorUrl: "https://validator.swagger.io/validator",
     requestInterceptor: (req) => {
         // Plain permalinks have no /wp-json route, so rewrite REST calls to
-        // the ?rest_route= form. Only touch requests under the REST base path;
-        // the schema fetch (?swagger_api=schema) is left alone.
+        // the ?rest_route= form. Swagger UI drops the query from the server
+        // URL and prepends only its path (cfg.strip), which we strip back off
+        // to recover the route. The schema fetch and cross-origin requests
+        // (e.g. the validator) are left alone.
         const cfg = swagger_ui_app.rest_route;
-        if (cfg && cfg.enabled) {
-            const u = new URL(req.url);
-            if (cfg.basePath && u.pathname.indexOf(cfg.basePath) === 0) {
-                const route = u.pathname.slice(cfg.basePath.length);
-                const query = u.search ? u.search.slice(1) : '';
-                req.url = cfg.restRoot + '?rest_route=' + route + (query ? '&' + query : '');
-            }
+        if (!cfg || !cfg.enabled) {
+            return req;
         }
+        const base = new URL(cfg.restRoot);
+        const u = new URL(req.url);
+        if (u.origin !== base.origin || u.searchParams.has('swagger_api')) {
+            return req;
+        }
+        let route = u.pathname;
+        if (cfg.strip && cfg.strip !== '/' && route.indexOf(cfg.strip) === 0) {
+            route = route.slice(cfg.strip.length);
+        }
+        const query = u.search ? u.search.slice(1) : '';
+        req.url = base.origin + base.pathname + '?rest_route=' + route + (query ? '&' + query : '');
         return req;
     },
 });

--- a/swaggeropenapi.php
+++ b/swaggeropenapi.php
@@ -395,6 +395,13 @@ class Spec30Formatter implements SwaggerSpecFormatter {
 	}
 
 	private function mapServers(array $spec): array {
+		// Plain permalinks: advertise the honest ?rest_route= server so the
+		// dropdown matches the URL Try-it-out actually calls.
+		$cfg = WP_API_SwaggerUI::restRouteConfig();
+		if ( $cfg['enabled'] && ! empty( $cfg['server'] ) ) {
+			return array( array( 'url' => $cfg['server'] ) );
+		}
+
 		$host     = isset( $spec['host'] ) ? $spec['host'] : '';
 		$basePath = isset( $spec['basePath'] ) ? $spec['basePath'] : '';
 		$schemes  = ! empty( $spec['schemes'] ) ? $spec['schemes'] : array( 'https' );

--- a/swaggersetting.php
+++ b/swaggersetting.php
@@ -40,7 +40,7 @@ class SwaggerSetting {
 		$data['page_title']				 = get_admin_page_title();
 		$data['swagger_api_basepath']	 = WP_API_SwaggerUI::getCLeanNameSpace();
 		$data['namespaces']				 = rest_get_server()->get_namespaces();
-		$data['docs_url']				 = home_url( untrailingslashit( WP_API_SwaggerUI::rewriteBaseApi() ) . '/docs' );
+		$data['docs_url']				 = WP_API_SwaggerUI::endpointUrl( 'docs' );
 		$data['swagger_api_auth_schemes'] = (array) get_option( 'swagger_api_auth_schemes', array( 'basic' ) );
 		$data['spec_versions']			 = SwaggerSpecRegistry::versions();
 		$data['swagger_api_spec_version'] = get_option( 'swagger_api_spec_version', '2.0' );

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -79,7 +79,7 @@ class SwaggerTemplate
             wp_enqueue_script('swagger-ui', WP_API_SwaggerUI::pluginUrl('assets/js/app.js'), $info_js['dependencies'], $info_js['version'], true);
 
             $l10n = array(
-                'schema_url' => home_url(WP_API_SwaggerUI::rewriteBaseApi() . '/schema')
+                'schema_url' => WP_API_SwaggerUI::endpointUrl('schema')
             );
             wp_localize_script('swagger-ui', 'swagger_ui_app', $l10n);
         }

--- a/swaggertemplate.php
+++ b/swaggertemplate.php
@@ -79,7 +79,8 @@ class SwaggerTemplate
             wp_enqueue_script('swagger-ui', WP_API_SwaggerUI::pluginUrl('assets/js/app.js'), $info_js['dependencies'], $info_js['version'], true);
 
             $l10n = array(
-                'schema_url' => WP_API_SwaggerUI::endpointUrl('schema')
+                'schema_url' => WP_API_SwaggerUI::endpointUrl('schema'),
+                'rest_route' => WP_API_SwaggerUI::restRouteConfig()
             );
             wp_localize_script('swagger-ui', 'swagger_ui_app', $l10n);
         }

--- a/tests/test-swaggeropenapi.php
+++ b/tests/test-swaggeropenapi.php
@@ -53,6 +53,24 @@ class TestSwaggerOpenApi extends WP_UnitTestCase {
 		$this->assertEquals( array( 'title' => 'T' ), $out['info'] );
 	}
 
+	public function test_spec30_plain_permalinks_advertise_single_rest_route_server() {
+		update_option( 'permalink_structure', '' );
+		update_option( 'swagger_api_spec_version', '3.0.3' );
+
+		$spec = array(
+			'info'     => array( 'title' => 'T' ),
+			'host'     => 'example.com',
+			'basePath' => '/wp-json',
+			'schemes'  => array( 'https', 'http' ),
+			'paths'    => array(),
+		);
+		$out = ( new Spec30Formatter() )->format( $spec );
+
+		$this->assertCount( 1, $out['servers'] );
+		$this->assertStringEndsWith( '?rest_route=', $out['servers'][0]['url'] );
+		$this->assertStringNotContainsString( 'wp-json', $out['servers'][0]['url'] );
+	}
+
 	public function test_spec30_security_schemes() {
 		$spec = array(
 			'host'                => 'e.com',

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -852,7 +852,6 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$cfg = WP_API_SwaggerUI::restRouteConfig();
 
 		$this->assertFalse($cfg['enabled']);
-		$this->assertStringEndsWith('/wp-json', $cfg['basePath']);
 	}
 
 	public function test_restRouteConfig_enabled_on_plain_permalinks()
@@ -862,8 +861,27 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$cfg = WP_API_SwaggerUI::restRouteConfig();
 
 		$this->assertTrue($cfg['enabled']);
-		$this->assertStringEndsWith('/wp-json', $cfg['basePath']);
 		$this->assertStringNotContainsString('?', $cfg['restRoot']);
+	}
+
+	public function test_restRouteConfig_strip_is_rest_prefix_for_swagger2()
+	{
+		update_option('swagger_api_spec_version', '2.0');
+
+		$cfg = WP_API_SwaggerUI::restRouteConfig();
+
+		$this->assertStringEndsWith('/wp-json', $cfg['strip']);
+		$this->assertNull($cfg['server']);
+	}
+
+	public function test_restRouteConfig_advertises_rest_route_server_for_openapi3()
+	{
+		update_option('swagger_api_spec_version', '3.0.3');
+
+		$cfg = WP_API_SwaggerUI::restRouteConfig();
+
+		$this->assertStringEndsWith('?rest_route=', $cfg['server']);
+		$this->assertStringNotContainsString('wp-json', $cfg['server']);
 	}
 
 }

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -825,4 +825,24 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$this->assertTrue( in_array( 'application/json', $consumes, true ) );
 	}
 
+	public function test_endpointUrl_emits_query_string_form()
+	{
+		$url = WP_API_SwaggerUI::endpointUrl('docs');
+
+		$this->assertStringContainsString('swagger_api=docs', $url);
+		$this->assertStringStartsWith(home_url('/'), $url);
+
+		parse_str((string) parse_url($url, PHP_URL_QUERY), $qs);
+		$this->assertSame('docs', $qs['swagger_api']);
+	}
+
+	public function test_endpointUrl_works_when_permalinks_are_plain()
+	{
+		update_option('permalink_structure', '');
+
+		$url = WP_API_SwaggerUI::endpointUrl('schema');
+
+		$this->assertStringContainsString('swagger_api=schema', $url);
+	}
+
 }

--- a/tests/test-swaggerui.php
+++ b/tests/test-swaggerui.php
@@ -845,4 +845,25 @@ class TestSwaggerUI extends WP_UnitTestCase {
 		$this->assertStringContainsString('swagger_api=schema', $url);
 	}
 
+	public function test_restRouteConfig_disabled_on_pretty_permalinks()
+	{
+		update_option('permalink_structure', '/%postname%/');
+
+		$cfg = WP_API_SwaggerUI::restRouteConfig();
+
+		$this->assertFalse($cfg['enabled']);
+		$this->assertStringEndsWith('/wp-json', $cfg['basePath']);
+	}
+
+	public function test_restRouteConfig_enabled_on_plain_permalinks()
+	{
+		update_option('permalink_structure', '');
+
+		$cfg = WP_API_SwaggerUI::restRouteConfig();
+
+		$this->assertTrue($cfg['enabled']);
+		$this->assertStringEndsWith('/wp-json', $cfg['basePath']);
+		$this->assertStringNotContainsString('?', $cfg['restRoot']);
+	}
+
 }

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: WP API SwaggerUI
  * Description: WordPress REST API with Swagger UI.
- * Version:     2.3.0
+ * Version:     2.4.0
  * Author:      Agus Suroyo
  * Requires PHP: 7.4
  * License:     GPL v2 or later

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -133,13 +133,29 @@ class WP_API_SwaggerUI
     // ?rest_route= form when permalinks are Plain. rest_url() has no pretty
     // /wp-json route then, so Swagger UI's server+path URLs 404; the JS
     // requestInterceptor uses this to rebuild each REST call.
+    //
+    // strip = the URL path Swagger UI prepends for the active spec version.
+    // OpenAPI 3.0 can advertise an honest ?rest_route= server (returned in
+    // 'server'); Swagger 2.0's host+basePath cannot carry a query string, so
+    // it keeps the /wp-json base and only the interceptor makes it work.
     public static function restRouteConfig()
     {
-        $self = new self();
+        $rest_root = explode('?', rest_url('/'))[0];
+        $self      = new self();
+
+        if ('3.0.3' === get_option('swagger_api_spec_version', '2.0')) {
+            $server = $rest_root . '?rest_route=';
+            $strip  = parse_url($rest_root, PHP_URL_PATH);
+        } else {
+            $server = null;
+            $strip  = $self->getBasePath();
+        }
+
         return array(
             'enabled'  => ! get_option('permalink_structure'),
-            'basePath' => $self->getBasePath(),
-            'restRoot' => explode('?', rest_url('/'))[0],
+            'restRoot' => $rest_root,
+            'strip'    => $strip,
+            'server'   => $server,
         );
     }
 

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -52,6 +52,11 @@ class WP_API_SwaggerUI
         return plugin_dir_url(__FILE__) . $path;
     }
 
+    public static function endpointUrl($endpoint)
+    {
+        return add_query_arg('swagger_api', $endpoint, home_url('/'));
+    }
+
     public static function pluginPath($path)
     {
         return plugin_dir_path(__FILE__) . $path;

--- a/wp-api-swaggerui.php
+++ b/wp-api-swaggerui.php
@@ -129,6 +129,20 @@ class WP_API_SwaggerUI
         return rtrim($path, '/') . '/' . ltrim(rest_get_url_prefix(), '/');
     }
 
+    // Client-side data for rewriting Swagger UI Try-it-out requests to the
+    // ?rest_route= form when permalinks are Plain. rest_url() has no pretty
+    // /wp-json route then, so Swagger UI's server+path URLs 404; the JS
+    // requestInterceptor uses this to rebuild each REST call.
+    public static function restRouteConfig()
+    {
+        $self = new self();
+        return array(
+            'enabled'  => ! get_option('permalink_structure'),
+            'basePath' => $self->getBasePath(),
+            'restRoot' => explode('?', rest_url('/'))[0],
+        );
+    }
+
     public function getSchemes()
     {
         $schemes = [];


### PR DESCRIPTION
## Problem

Plugin's `docs` and `schema` endpoint URLs were emitted only in pretty-permalink form (`home_url('rest-api/docs')`). On sites using the **Plain** permalink setting, custom rewrite rules never fire, so those URLs 404. Endpoints must work on all permalink types.

## Root cause

`routes()` registers `add_rewrite_tag('%swagger_api%', ...)` with an empty `$query`, so WP core also calls `$wp->add_query_var('swagger_api')` — making `swagger_api` a **public query var**. `?swagger_api=docs|schema` already dispatches under any permalink. Only the URLs the plugin *emitted* were pretty-only.

## Change

- Add `WP_API_SwaggerUI::endpointUrl($endpoint)` → `add_query_arg('swagger_api', $endpoint, home_url('/'))`.
- Route `docs_url` (swaggersetting.php) and `schema_url` (swaggertemplate.php) through it.
- Rewrite rules left untouched — existing pretty bookmarks keep resolving.

## Tests

Full suite green (141 tests, 322 assertions). Added `test_endpointUrl_emits_query_string_form` and `test_endpointUrl_works_when_permalinks_are_plain`.